### PR TITLE
feat: Allow module replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,21 @@ shallow.mockPipe(MyPipe, input => `MyPipe: ${input}`);
 ```
 Tells Shallow to have the `MyPipe` always perform the following action on input data. This lets you inspect your templates and controls for your Pipe's side-effects.
 
+#### Replace a module with a test module
+Angular has a pattern in which they provide full-module replacements specifically designed for testing (see: [HttpClientTestingModule](https://angular.io/api/common/http/testing/HttpClientTestingModule)). These testing modules can be used in your Shallow tests by replacing the original module with the test module.
+
+```typescript
+shallow.replaceModule(HttpClientModule, HttpClientTestingModule);
+
+```
+
+If you would like to do this globally, you can use `alwaysReplaceModule` in your global test setup.
+
+```typescript
+Shallow.alwaysReplaceModule(HttpClientModule, HttpClientTestingModule);
+
+```
+
 #### Rendering with `render`
 Once you've completed your setup, the final step is rendering. Render takes two arguments:
 * `html` (optional) -  This will be the HTML that exercises your component.
@@ -451,6 +466,7 @@ Check out the [examples](lib/examples) folder for more specific use cases includ
 * [Using Injection Tokens](lib/examples/mocking-injection-tokens.spec.ts)
 * [Multiple components](lib/examples/multiple-components.spec.ts)
 * [Multiple modules](lib/examples/multiple-modules.spec.ts)
+* [Using replaceModule to substitute test modules](lib/examples/using-replacement-modules.spec.ts)
 * [Using dontMock to bypass mocking in a spec](lib/examples/using-dont-mock.spec.ts)
 * [Using alwaysMock to globally mock things](lib/examples/using-always-mock.spec.ts)
 * [Using alwaysProvide to globally provide things](lib/examples/using-always-provide.spec.ts)

--- a/lib/examples/using-replacement-modules.spec.ts
+++ b/lib/examples/using-replacement-modules.spec.ts
@@ -1,0 +1,58 @@
+import { Type, Component, NgModule } from '@angular/core';
+import { fakeAsync, tick } from '@angular/core/testing';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+@Component({
+  selector: 'service-response-label',
+  template: '<label>{{labelText}}</label>',
+})
+class FooLabelComponent {
+  labelText: string;
+
+  constructor(httpClient: HttpClient) {
+    httpClient.get<string>('/foo/as/a/service').toPromise()
+      .then(
+        response => this.labelText = response,
+        () => this.labelText = 'ERROR'
+      );
+  }
+}
+
+@NgModule({
+  imports: [HttpClientModule],
+  declarations: [FooLabelComponent],
+})
+class FooLabelModule {}
+//////////////////////////
+
+describe('using replaceModule', () => {
+  let shallow: Shallow<FooLabelComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(FooLabelComponent, FooLabelModule)
+      .replaceModule(HttpClientModule, HttpClientTestingModule);
+  });
+
+  it('displays the response from the foo service', fakeAsync(async () => {
+    const {element, get, fixture} = await shallow.render();
+    const client = get(HttpTestingController as Type<HttpTestingController>);
+    client.expectOne('/foo/as/a/service').flush('foo response');
+    tick();
+    fixture.detectChanges();
+
+    expect(element.nativeElement.innerText).toBe('foo response');
+  }));
+
+  it('displays ERROR when a service error occurs', fakeAsync(async () => {
+    const {element, get, fixture} = await shallow.render();
+    const client = get(HttpTestingController as Type<HttpTestingController>);
+    client.expectOne('/foo/as/a/service').error(new ErrorEvent('BOOM'));
+    tick();
+    fixture.detectChanges();
+
+    expect(element.nativeElement.innerText).toBe('ERROR');
+  }));
+});

--- a/lib/models/test-setup.ts
+++ b/lib/models/test-setup.ts
@@ -4,6 +4,7 @@ import { MockCache } from './mock-cache';
 export class TestSetup<TComponent> {
   readonly dontMock: any[] = [];
   readonly mocks = new Map<any, any>();
+  readonly moduleReplacements = new Map<Type<any>, Type<any>>();
   readonly mockPipes = new Map<PipeTransform | Type<PipeTransform>, Function>(); /* tslint:disable-line ban-types */
   readonly mockCache = new MockCache();
   readonly providers: Provider[] = [];

--- a/lib/shallow.spec.ts
+++ b/lib/shallow.spec.ts
@@ -39,6 +39,17 @@ describe('Shallow', () => {
     });
   });
 
+  describe('alwaysReplaceModule', () => {
+    it('modules are automatically added to setup.replacementModules on construction', () => {
+      class ReplacementModule {}
+      Shallow.alwaysReplaceModule(TestModule, ReplacementModule);
+      const shallow = new Shallow(TestComponent, TestModule);
+
+      expect(shallow.setup.moduleReplacements.get(TestModule))
+        .toBe(ReplacementModule);
+    });
+  });
+
   describe('alwaysMock', () => {
     it('items are automatically added to setup.mock on construction', () => {
       class MyService {
@@ -138,6 +149,17 @@ describe('Shallow', () => {
 
       const transform = shallow.setup.mockPipes.get(TestPipe);
       expect(transform && transform()).toEqual({test: 'mocked pipe'});
+    });
+  });
+
+  describe('replaceModule', () => {
+    it('adds replacementModule', () => {
+      class ReplacementModule {}
+      const shallow = new Shallow(TestComponent, TestModule)
+        .replaceModule(TestModule, ReplacementModule);
+
+      expect(shallow.setup.moduleReplacements.get(TestModule))
+        .toBe(ReplacementModule);
     });
   });
 });

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -39,24 +39,32 @@ export class Shallow<TTestComponent> {
     return Shallow;
   }
 
+  // Always replace one module with another replacement module.
+  private static readonly _alwaysReplaceModule = new Map<Type<any>, Type<any>>();
+  static alwaysReplaceModule(originalModule: Type<any>, replacementModule: Type<any>): typeof Shallow {
+    Shallow._alwaysReplaceModule.set(originalModule, replacementModule);
+    return Shallow;
+  }
+
   constructor(testComponent: Type<TTestComponent>, testModule: Type<any>) {
     this.setup = new TestSetup(testComponent, testModule);
     this.setup.dontMock.push(testComponent, ...Shallow._neverMock);
     this.setup.providers.push(...Shallow._alwaysProvide);
     Shallow._alwaysMock.forEach((value, key) => this.setup.mocks.set(key, value));
+    Shallow._alwaysReplaceModule.forEach((value, key) => this.setup.moduleReplacements.set(key, value));
   }
 
-  provide(...providers: Provider[]) {
+  provide(...providers: Provider[]): this {
     this.setup.providers.push(...providers);
     return this;
   }
 
-  dontMock(...things: any[]) {
+  dontMock(...things: any[]): this {
     this.setup.dontMock.push(...things);
     return this;
   }
 
-  mock<TMock>(mockClass: Type<TMock> | InjectionToken<TMock>, stubs: Partial<TMock>) {
+  mock<TMock>(mockClass: Type<TMock> | InjectionToken<TMock>, stubs: Partial<TMock>): this {
     const mock = this.setup.mocks.get(mockClass) || {};
     this.setup.mocks.set(mockClass, {...mock, ...stubs as object});
     return this;
@@ -64,6 +72,11 @@ export class Shallow<TTestComponent> {
 
   mockPipe<TPipe extends PipeTransform>(pipe: Type<TPipe>, transform: TPipe['transform']) {
     this.setup.mockPipes.set(pipe, transform);
+    return this;
+  }
+
+  replaceModule(originalModule: Type<any>, replacementModule: Type<any>): this {
+    this.setup.moduleReplacements.set(originalModule, replacementModule);
     return this;
   }
 

--- a/lib/tools/mock-module.ts
+++ b/lib/tools/mock-module.ts
@@ -25,6 +25,11 @@ export function mockModule<TModule extends AnyNgModule>(mod: TModule, setup: Tes
   }
 
   const modClass = mod as Type<any>;
+  const replacementModule = setup.moduleReplacements.get(modClass);
+  if (replacementModule) {
+    return setup.mockCache.add(mod, replacementModule) as TModule;
+  }
+
   const {imports, declarations, exports, entryComponents, providers} = getNgModuleAnnotations(modClass);
   const mockedModule: NgModule = {
     imports: ngMock(imports, setup),


### PR DESCRIPTION
Fixes #19 
From the docs:

#### Replace a module with a test module
Angular has a pattern in which they provide full-module replacements specifically designed for testing (see: [HttpClientTestingModule](https://angular.io/api/common/http/testing/HttpClientTestingModule)). These testing modules can be used in your Shallow tests by replacing the original module with the test module.

```typescript
shallow.replaceModule(HttpClientModule, HttpClientTestingModule);

```

If you would like to do this globally, you can use `alwaysReplaceModule` in your global test setup.

```typescript
Shallow.alwaysReplaceModule(HttpClientModule, HttpClientTestingModule);

```
