### PR TITLE
feat: Allow binding directly to component @Input properties

### DIFF
--- a/lib/examples/using-no-template-render.spec.ts
+++ b/lib/examples/using-no-template-render.spec.ts
@@ -1,0 +1,46 @@
+import { Input, Output, EventEmitter, Component, NgModule } from '@angular/core';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+@Component({
+  selector: 'name',
+  template: `
+    <label (click)="select.emit(name)">{{name}}</label>
+  `,
+})
+class NameComponent {
+  @Input() name = 'DEFAULT NAME';
+  @Output() select = new EventEmitter<string>();
+}
+
+@NgModule({
+  declarations: [NameComponent]
+})
+class NameModule {}
+//////////////////////////
+
+describe('No-Template Rendering', () => {
+  let shallow: Shallow<NameComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(NameComponent, NameModule);
+  });
+
+  it('displays and tracks the name', async () => {
+    const {find, instance} = await shallow.render({
+      bind: { name: 'Chuck Norris' }
+    });
+    const label = find('label');
+    label.nativeElement.click();
+
+    expect(label.nativeElement.textContent).toBe('Chuck Norris');
+    expect(instance.select.emit).toHaveBeenCalledWith('Chuck Norris');
+  });
+
+  it('uses the default name', async () => {
+    const {find, instance} = await shallow.render();
+
+    find('label').nativeElement.click();
+    expect(instance.select.emit).toHaveBeenCalledWith('DEFAULT NAME');
+  });
+});

--- a/lib/models/renderer.spec.ts
+++ b/lib/models/renderer.spec.ts
@@ -1,0 +1,99 @@
+import { Input, Output, Component, EventEmitter, NgModule } from '@angular/core';
+import { Renderer } from './renderer';
+import { TestSetup } from './test-setup';
+
+@Component({
+  selector: 'thing',
+  template: '<div></div>'
+})
+class TestComponent {
+  @Input('renamedInput') fooInput: string;
+  @Input() myInput: string;
+  myProperty: string;
+  @Output() myOutput = new EventEmitter<any>();
+  emitterWithoutOutputDecorator = new EventEmitter<any>();
+}
+
+@NgModule({
+  declarations: [TestComponent]
+})
+class TestModule {}
+
+describe('Renderer', () => {
+  let renderer: Renderer<TestComponent>;
+  beforeEach(() => {
+    const setup = new TestSetup(TestComponent, TestModule);
+    setup.dontMock.push(TestComponent);
+    renderer = new Renderer(setup);
+  });
+
+  it('spys on output event emitters', async () => {
+    const {instance} = await renderer.render();
+    instance.myOutput.emit('FOO');
+
+    // Spys have a `calls` property on them. This is the only way I know
+    // how to detect an existing spy.
+    expect((instance.myOutput.emit as jasmine.Spy).calls).toBeDefined();
+    expect(instance.myOutput.emit).toHaveBeenCalledWith('FOO');
+  });
+
+  it('does not spy on event emitters that are not marked as @Output', async () => {
+    const {instance} = await renderer.render();
+    instance.emitterWithoutOutputDecorator.emit('FOO');
+
+    // Spys have a `calls` property on them. This is the only way I know
+    // how to detect an existing spy.
+    expect((instance.emitterWithoutOutputDecorator.emit as jasmine.Spy).calls)
+      .not.toBeDefined();
+  });
+
+  describe('with only template', () => {
+    it('wraps the rendering in a container', async () => {
+      const {fixture} = await renderer.render('<thing></thing>');
+
+      expect(fixture.componentInstance instanceof TestComponent).toBe(false);
+    });
+  });
+
+  describe('with no arguments', () => {
+    it('renders the component directly', async () => {
+      const {fixture} = await renderer.render();
+
+      expect(fixture.componentInstance instanceof TestComponent).toBe(true);
+    });
+
+  });
+
+  describe('with only renderOptions', () => {
+    it('renders the component directly', async () => {
+      const {fixture} = await renderer.render({});
+
+      expect(fixture.componentInstance instanceof TestComponent).toBe(true);
+    });
+
+    it('binds directly to the component', async () => {
+      const {instance} = await renderer.render({
+        bind: {myInput: 'FOO'}
+      });
+
+      expect(instance.myInput).toBe('FOO');
+    });
+
+    it('works on renamed @Input properties', async () => {
+      await renderer.render({
+        bind: {fooInput: 'FOO'}
+      });
+    });
+
+    it('throws an error when binding to a property that is not marked as an @Input', async (done) => {
+      try {
+        await renderer.render({
+          bind: {myProperty: 'FOO'}
+        });
+        fail('Render should have thrown an error because the myProperty is not an @Input');
+      } catch {
+        done();
+      }
+    });
+  });
+});

--- a/lib/models/renderer.ts
+++ b/lib/models/renderer.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Rendering, RenderOptions } from './rendering';
 import { createContainer } from '../tools/create-container';
@@ -6,18 +7,39 @@ import { directiveResolver } from '../tools/reflect';
 import { mockProvider } from '../tools/mock-provider';
 import { copyTestModule } from '../tools/copy-test-module';
 
+export class InvalidInputBindError {
+  message = `Tried to bind to a property that is not marked as @Input: ${this.key}\nAvailable input bindings: ${this.availableInputs}`;
+  constructor(public availableInputs: string[], public key: string) {}
+}
+
 export class Renderer<TComponent> {
   constructor(private readonly _setup: TestSetup<TComponent>) {}
 
-  async render<TBindings>(html?: string, options?: Partial<RenderOptions<TBindings>>) {
+  render<TBindings extends Partial<TComponent>>(
+    options: Partial<RenderOptions<TBindings>>
+  ): Promise<Rendering<TComponent, TBindings>>;
+
+  render<TBindings>(
+    template?: string,
+    options?: Partial<RenderOptions<TBindings>>
+  ): Promise<Rendering<TComponent, TBindings>>;
+
+  async render<TBindings>(
+    templateOrOptions?: string | Partial<RenderOptions<TBindings>>,
+    optionsOrUndefined?: Partial<RenderOptions<TBindings>>
+  ) {
+    const [template, options] = typeof templateOrOptions === 'string'
+      ? [templateOrOptions, optionsOrUndefined]
+      : [undefined, templateOrOptions];
+
     const finalOptions = {
       detectChanges: true,
       bind: {} as TBindings,
       ...options,
     };
 
-    const ComponentClass = html
-      ? createContainer(html, finalOptions.bind)
+    const ComponentClass = template
+      ? createContainer(template, finalOptions.bind)
       : this._setup.testComponent;
 
     // Components may have their own providers, If the test component does,
@@ -39,10 +61,34 @@ export class Renderer<TComponent> {
       }).compileComponents();
 
     const fixture = TestBed.createComponent(ComponentClass);
+    const rendering = new Rendering(fixture, finalOptions.bind, this._setup);
+
+    if (resolvedTestComponent.outputs) {
+      resolvedTestComponent.outputs.forEach(k => {
+        const value = (rendering.instance as any)[k];
+        if (value && value instanceof EventEmitter) {
+          spyOn(value, 'emit').and.callThrough();
+        }
+      });
+    }
+
+    if (!template) {
+      // If no template is used, the bindings should go directly to the
+      // component @Inputs
+      const inputPropertyNames = (resolvedTestComponent.inputs || [])
+        .map(k => k.split(':')[0]);
+      Object.keys(finalOptions.bind).forEach(k => {
+        if (!inputPropertyNames.includes(k)) {
+          throw new InvalidInputBindError(inputPropertyNames, k);
+        }
+        (rendering.instance as any)[k] = (finalOptions.bind as any)[k];
+      });
+    }
+
     if (finalOptions.detectChanges) {
       fixture.detectChanges();
     }
 
-    return new Rendering(fixture, finalOptions.bind, this._setup);
+    return rendering;
   }
 }

--- a/lib/shallow.spec.ts
+++ b/lib/shallow.spec.ts
@@ -1,17 +1,26 @@
 import { Shallow } from './shallow';
-import { PipeTransform, InjectionToken } from '@angular/core';
+import { Pipe, Component, NgModule, PipeTransform, InjectionToken } from '@angular/core';
 
 class TestService {
   foo() { return 'foo'; }
   bar() { return 'bar'; }
 }
-class TestComponent {}
-class TestModule {}
+@Component({
+  selector: 'test',
+  template: '<hr/>'
+}) class TestComponent {}
+
+@Pipe({name: 'test'})
 class TestPipe implements PipeTransform {
   transform(key: string) {
     return {test: 'pipe'};
   }
 }
+
+@NgModule({
+  declarations: [TestComponent, TestPipe]
+})
+class TestModule {}
 
 describe('Shallow', () => {
   it('includes the testComponent in setup.dontMock', () => {
@@ -160,6 +169,29 @@ describe('Shallow', () => {
 
       expect(shallow.setup.moduleReplacements.get(TestModule))
         .toBe(ReplacementModule);
+    });
+  });
+
+  describe('render', () => {
+    it('can render with only HTML', async () => {
+      const {instance} = await new Shallow(TestComponent, TestModule)
+        .render('<test></test>');
+
+      expect(instance instanceof TestComponent).toBe(true);
+    });
+
+    it('can render with no parameters', async () => {
+      const {instance} = await new Shallow(TestComponent, TestModule)
+        .render();
+
+      expect(instance instanceof TestComponent).toBe(true);
+    });
+
+    it('can render with only renderOptions', async () => {
+      const {instance} = await new Shallow(TestComponent, TestModule)
+        .render({detectChanges: false});
+
+      expect(instance instanceof TestComponent).toBe(true);
     });
   });
 });

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -76,8 +76,31 @@ export class Shallow<TTestComponent> {
     return this;
   }
 
-  async render<TBindings>(html?: string, renderOptions?: Partial<RenderOptions<TBindings>>): Promise<Rendering<TTestComponent, TBindings>> {
+  // Render no options, just the component and no bindings
+  render(): Promise<Rendering<TTestComponent, never>>;
+
+  render<TBindings>(
+    html: string,
+    renderOptions?: Partial<RenderOptions<TBindings>>
+  ): Promise<Rendering<TTestComponent, TBindings>>;
+
+  // Render with just renderOptions, means you must provide bindings that match
+  // the TestComponent
+  render<TBindings extends Partial<TTestComponent>>(
+    renderOptions?: Partial<RenderOptions<TBindings>>
+  ): Promise<Rendering<TTestComponent, TBindings>>;
+
+  async render<TBindings>(
+    htmlOrRenderOptions?: string | Partial<RenderOptions<TBindings>>,
+    renderOptions?: Partial<RenderOptions<TBindings>>
+  ) {
     const renderer = new Renderer(this.setup);
-    return renderer.render(html, renderOptions);
+    if (typeof htmlOrRenderOptions === 'string') {
+      return renderer.render(htmlOrRenderOptions, renderOptions);
+    } else if (htmlOrRenderOptions !== undefined) {
+      return renderer.render(htmlOrRenderOptions);
+    } else {
+      return renderer.render();
+    }
   }
 }


### PR DESCRIPTION
Two new features here:
* Allows rendering without specifying the HTML template while also binding directly to the component properties. Thanks for the idea @ike18t!
* Automatically spy on `@Output` `EventEmitters`

Example:
```typescript
@Component({
  selector: 'my-component',
  template: '<span (click)="clickName.emit(name)">{{name}}</span>'
})
class MyComponent {
  @Input() name: string;
  @Output() clickName = new EventEmitter<string>();
}
```
```typescript
it('can bind directly to inputs', async () => {
  const {find} = await shallow.render({bind: {name: 'FOO'}});

  expect(find('label').nativeElement.textContent).toBe('FOO');
});

it('automatically spys on @Outputs', async () => {
  const {find, instance} = await shallow.render({bind: {name: 'BAR'}});
  find('label').click();

  expect(instance.clickName.emit).toHaveBeenCalledWith('BAR');
});
```