### PR TITLE
feat: Support mocking static functions

### DIFF
--- a/lib/examples/mocking-static-methods.spec.ts
+++ b/lib/examples/mocking-static-methods.spec.ts
@@ -1,0 +1,46 @@
+import { Component, Input, NgModule } from '@angular/core';
+import { Shallow } from '../shallow';
+
+class Foo { // tslint:disable-line no-unnecessary-class
+  static fooify(name: string) {
+    return `${name}-foo`;
+  }
+}
+////// Module Setup //////
+
+@Component({
+  selector: 'foo',
+  template: '<div>{{fooified}}</div>',
+})
+class FooComponent {
+  @Input() name: string;
+  get fooified() { return Foo.fooify(this.name); }
+}
+
+@NgModule({
+  declarations: [FooComponent]
+})
+class FooModule {}
+//////////////////////////
+
+describe('Mocking static methods', () => {
+  let shallow: Shallow<FooComponent>;
+  beforeEach(() => {
+    shallow = new Shallow(FooComponent, FooModule);
+  });
+
+  it('can mock a static method on a class', async () => {
+    const {element} = await shallow
+      .mockStatic(Foo, {fooify: (name: string) => `${name}-MOCK FOO`})
+      .render('<foo name="blah"></foo>');
+
+    expect(element.nativeElement.textContent).toBe('blah-MOCK FOO');
+  });
+
+  it('does not mock static methods by default', async () => {
+    const {element} = await shallow
+      .render('<foo name="blah"></foo>');
+
+    expect(element.nativeElement.textContent).toBe('blah-foo');
+  });
+});

--- a/lib/models/test-setup.ts
+++ b/lib/models/test-setup.ts
@@ -4,6 +4,7 @@ import { MockCache } from './mock-cache';
 export class TestSetup<TComponent> {
   readonly dontMock: any[] = [];
   readonly mocks = new Map<any, any>();
+  readonly staticMocks = new Map<any, any>();
   readonly moduleReplacements = new Map<Type<any>, Type<any> | ModuleWithProviders>();
   readonly mockPipes = new Map<PipeTransform | Type<PipeTransform>, Function>(); /* tslint:disable-line ban-types */
   readonly mockCache = new MockCache();

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -2,7 +2,7 @@ import { InjectionToken, ModuleWithProviders, Type, PipeTransform, Provider } fr
 import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { RenderOptions, Rendering } from './models/rendering';
-import { Renderer } from './models/renderer';
+import { Renderer, InvalidStaticPropertyMockError } from './models/renderer';
 import { TestSetup } from './models/test-setup';
 import './tools/jasmine-matchers';
 
@@ -63,6 +63,15 @@ export class Shallow<TTestComponent> {
   mock<TMock>(mockClass: Type<TMock> | InjectionToken<TMock>, stubs: Partial<TMock>): this {
     const mock = this.setup.mocks.get(mockClass) || {};
     this.setup.mocks.set(mockClass, {...mock, ...stubs as object});
+    return this;
+  }
+
+  // TODO: Support property mocks or use a conditional partial type (TS 2.8+)to exclude non-function properties
+  mockStatic<TMock extends object>(obj: TMock, stubs: Partial<TMock>): this {
+    InvalidStaticPropertyMockError
+      .checkMockForStaticProperties(stubs);
+    const mock = this.setup.staticMocks.get(obj) || {};
+    this.setup.staticMocks.set(obj, {...mock, ...stubs as object});
     return this;
   }
 


### PR DESCRIPTION
Support for mocking static methods:

```typescript
class MyClass {
  static reverse(thing: string) {
    return thing.split('').reverse();
  }
}
```

can be mocked with:
```typescript
shallow.mockStatic(MyClass, {reverse: () => 'mock reverse'});
```

Regular objects can be mocked in this manner too:
```typescript
const FOO = {
  bar: () => 'bar'
};
```
Can be mocked with:
```typescript
shallow.mockStatic(FOO, {bar: () => 'mocked bar'});
```

Due to Jasmine spy limitations, **only methods are supported**. If you try to mock a non-method property, an error is thrown. When we begin supporting other test frameworks this limitation may go away (or only exist when using Jasmine).

```typescript
class MyClass {
  static foo = 'FOO'
}
```

If you try to mock non-method property `MyClass.foo` will throw an error:
```typescript
shallow.mockStatic(MyClass, {foo: 'MOCK FOO'}); // throws: InvalidStaticPropertyMockError
```