### PR TITLE
fix: Make dontMock work provider arrays

### DIFF
--- a/lib/tools/mock-provider.spec.ts
+++ b/lib/tools/mock-provider.spec.ts
@@ -91,4 +91,14 @@ describe('mockPrivider', () => {
     expect(providers[1].provide).toBe(BarService);
     expect(providers[1].useValue instanceof MockOfProvider).toBe(true);
   });
+
+  it('mocks services even when they are part of a provider array in dontMock', () => {
+    // Angular allows a provider to be defined as an array of providers
+    // so in this instance, adding an array that contains FooService *should*
+    // be the same as adding just FooService.
+    testSetup.dontMock.push([FooService]);
+    const providers = mockProvider([FooService], testSetup) as any[];
+
+    expect(providers[0]).toBe(FooService);
+  });
 });

--- a/lib/tools/mock-provider.ts
+++ b/lib/tools/mock-provider.ts
@@ -4,6 +4,9 @@ import { TestSetup } from '../models/test-setup';
 import { isClassProvider, isFactoryProvider, isExistingProvider, isTypeProvider } from './type-checkers';
 import { getProviderName } from './get-provider-name';
 
+const recursiveIncludes = (array: any[], item: any): boolean =>
+  !!array.find(i => i === item || (Array.isArray(i) && recursiveIncludes(i, item)));
+
 export function mockProvider(provider: TypeProvider, setup: TestSetup<any>): ValueProvider | TypeProvider;
 export function mockProvider<TProvider extends Provider>(provider: TProvider, setup: TestSetup<any>): TProvider;
 export function mockProvider(provider: Provider, setup: TestSetup<any>): Provider {
@@ -17,7 +20,7 @@ export function mockProvider(provider: Provider, setup: TestSetup<any>): Provide
   const userMocks = setup.mocks.get(provide);
 
   // TODO: What if setup.dontMock.includes(provide.useClass)?
-  if (!userMocks && setup.dontMock.includes(provide)) {
+  if (!userMocks && recursiveIncludes(setup.dontMock, provide)) {
     return provider;
   }
 


### PR DESCRIPTION
There was a bug that would prevent `dontMock` and `neverMock` from skipping mocks for providers in a `forRoot` array unless you used the exact same array reference in your `dontMock` call.

For example:
```typescript
@NgModule()
class MyModule {
  static forRoot(): NgModuleWithProviders {
    return {
     ngModule: MyModule,
     providers: [FooService, BarService]
  }
}
```

Mocking the `forRoot` providers like this, would not work because each call to `forRoot` yields a new array reference.
```typescript
shallow.dontMock(MyModule.forRoot().providers);
```

This fixes that bug so it works now.
