### PR TITLE
feat: Support ModuleWithProviders in Shallow constructor

### DIFF
--- a/lib/examples/module-with-providers.spec.ts
+++ b/lib/examples/module-with-providers.spec.ts
@@ -1,0 +1,46 @@
+import { Injectable, Component, NgModule, ModuleWithProviders } from '@angular/core';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+@Injectable()
+class RedService {
+  color() {
+    return 'RED';
+  }
+}
+
+@Component({
+  selector: 'color-label',
+  template: '<label>{{redService.color()}}</label>',
+})
+class ColorLabelComponent {
+  constructor(public redService: RedService) {}
+}
+
+@NgModule({
+  declarations: [ColorLabelComponent],
+})
+class ColorModule { // tslint:disable-line no-unnecessary-class
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: ColorModule,
+      providers: [RedService],
+    };
+  }
+}
+//////////////////////////
+
+describe('module with forRoot', () => {
+  let shallow: Shallow<ColorLabelComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(ColorLabelComponent, ColorModule.forRoot())
+      .mock(RedService, {color: () => 'MOCKED COLOR'});
+  });
+
+  it('Uses the color from the RedService', async () => {
+    const {element} = await shallow.render('<color-label></color-label>');
+
+    expect(element.nativeElement.innerText).toBe('MOCKED COLOR');
+  });
+});

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -42,7 +42,7 @@ export class Shallow<TTestComponent> {
     return Shallow;
   }
 
-  constructor(testComponent: Type<TTestComponent>, testModule: Type<any>) {
+  constructor(testComponent: Type<TTestComponent>, testModule: Type<any> | ModuleWithProviders) {
     this.setup = new TestSetup(testComponent, testModule);
     this.setup.dontMock.push(testComponent, ...Shallow._neverMock);
     this.setup.providers.push(...Shallow._alwaysProvide);


### PR DESCRIPTION
Sometimes, you may want to test your component's module uses the `forRoot` pattern. Previously, you would have to manually `.provide()` any service dependencies when your module used the `forRoot` pattern but with this fix, you can use the `forRoot` output directly in the `Shallow` constructor:

#### Module
```typescript
@NgModule({
  declarations: [MyComponent]
})
class MyModule {
  static forRoot(): ModuleWithProviders {
    return {
      ngModule: MyModule,
      providers: [MyService],
  }
}
```
### Before
```typescript
shallow = new Shallow(MyComponent, MyModule)
  .provide(MyService);
```

### After
```typescript
shallow = new Shallow(MyComponent, MyModule.forRoot());
```