### PR TITLE
feat: Automatically wait for fixture stability (fixture.whenStable())…

### DIFF
--- a/lib/models/renderer.ts
+++ b/lib/models/renderer.ts
@@ -64,8 +64,9 @@ export class Renderer<TComponent> {
       ? [templateOrOptions, optionsOrUndefined]
       : [undefined, templateOrOptions];
 
-    const finalOptions = {
+    const finalOptions: RenderOptions<TBindings> = {
       detectChanges: true,
+      whenStable: true,
       bind: {} as TBindings,
       ...options,
     };
@@ -118,6 +119,11 @@ export class Renderer<TComponent> {
         }
         (rendering.instance as any)[k] = (finalOptions.bind as any)[k];
       });
+    }
+
+    if (finalOptions.whenStable) {
+      fixture.detectChanges();
+      await fixture.whenStable();
     }
 
     if (finalOptions.detectChanges) {

--- a/lib/models/rendering.ts
+++ b/lib/models/rendering.ts
@@ -6,6 +6,7 @@ import { TestSetup } from './test-setup';
 
 export interface RenderOptions<TBindings> {
   detectChanges: boolean;
+  whenStable: boolean;
   bind: TBindings;
 }
 


### PR DESCRIPTION
### Wait for `fixture.whenStable()` on render by default
It is common for components to implement `OnInit` and perform some sort of asynchronous initialization when the component is loaded. When using `TestBed` to test your component, you would generally use some sort of `fakeAsync`/`tick` combo (ugh..), or use `fixture.whenStable()` to wait for the async queue to be expunged.

When testing with Shallow, you generally have all your async service calls mocked out before you render your component so we could/should handle this async queue expunging automatically.

Here's a simple example of an async init:

```typescript
@Component({
  selector: 'my-component',
  template: '<div *ngIf="!loading">{{data.name}}</div>'
})
class MyComponent extends OnInit {
  data: MyServiceResponse;
  get loading() { return this.data === undefined; }

  constructor(private _myService: MyService) {}

  async ngOnInit() {
    this.data = await this._myService.loadStuff();
  }
}
```
Our test setup:
```typescript
beforeEach(() => {
  shallow = new Shallow(MyComponent, MyModule)
    .mock(MyService, {loadStuff: () => Promise.resolve({name: 'FOO'})});
});
```

Before this change, you'd have to handle it manually like so:
```typescript
it('displays the name', async () => {
  const {find, fixture} = await shallow.render();
  await fixture.whenStable(); // boilerplate..
  fixture.detectChanges();  // more boilerplate..

  expect(find('div').nativeElement.textContent).toBe('FOO');
});
```

Or alternatively there's `fakeAsync` (I'm not a fan of this if you can't tell already):

```typescript
it('displays the name', fakeAsync(async () => {
  const {find, fixture} = await shallow.render();
  tick(); // so weird!
  fixture.detectChanges();

  expect(find('div').nativeElement.textContent).toBe('FOO');
}));
```
We can do better:

After this change, it's a little easier:
```typescript
it('displays the name', async () => {
  const {find} = await shallow.render();

  expect(find('div').nativeElement.textContent).toBe('FOO');
});
```

Because we now automatically wait for `fixture.whenStable()` we can eliminate the extra steps. Small win!

> What if I want to test the component state while the async requests are pending?

You can disable the `whenStable` check with a parameter to the `shallow.render()` options:
```typescript
it('does not display anything while loading', async () => {
  const {find} = await shallow.render({whenStable: false});
  
  expect(find('div')).toHaveFound(0);
});
```