### PR TITLE
fix: Do not mock providers for replacement modules

### DIFF
--- a/lib/examples/component-with-routing.spec.ts
+++ b/lib/examples/component-with-routing.spec.ts
@@ -19,8 +19,8 @@ class GoHomeLinkComponent {
 
   constructor(public router: Router) {}
 
-  goHome() {
-    this.router.navigate(['home']);
+  async goHome() {
+    await this.router.navigate(['home']);
   }
 }
 const routes: Routes = [

--- a/lib/examples/component-with-routing.spec.ts
+++ b/lib/examples/component-with-routing.spec.ts
@@ -1,0 +1,67 @@
+import { APP_BASE_HREF, Location } from '@angular/common';
+import { Component, NgModule } from '@angular/core';
+import { RouterModule, Router, Routes } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Shallow } from '../shallow';
+
+//////////////////////////////////////////////////////////////
+// See Angular docs here:
+// https://angular.io/api/router/testing/RouterTestingModule
+//////////////////////////////////////////////////////////////
+
+////// Module Setup //////
+@Component({
+  selector: 'go-home-link',
+  template: '<a (click)="goHome()">Go somewhere</a>',
+})
+class GoHomeLinkComponent {
+  labelText: string;
+
+  constructor(public router: Router) {}
+
+  goHome() {
+    this.router.navigate(['home']);
+  }
+}
+const routes: Routes = [
+  {path: 'home', component: class DummyComponent {}}
+];
+
+// You probabaly want to export this ref from your module
+// so we can give Shallow specs access to it too.
+const routerModuleRef = RouterModule.forRoot(routes);
+@NgModule({
+  imports: [routerModuleRef],
+  providers: [{provide: APP_BASE_HREF, useValue: '/'}],
+  declarations: [GoHomeLinkComponent],
+})
+class GoHomeModule {}
+//////////////////////////
+
+describe('component with routing', () => {
+  let shallow: Shallow<GoHomeLinkComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(GoHomeLinkComponent, GoHomeModule)
+      //////////////////////////
+      // These are good candidates for global setup
+      // using `neverMock` and `alwaysProvide`
+      .dontMock(routerModuleRef)
+      .provide({provide: APP_BASE_HREF, useValue: '/'})
+      .dontMock(APP_BASE_HREF)
+      ///////////////////////////
+      .replaceModule(
+        routerModuleRef,
+        RouterTestingModule.withRoutes(routes)
+      );
+  });
+
+  it('uses the route', async () => {
+    const {fixture, find, get} = await shallow.render();
+    const location = get(Location);
+    find('a').triggerEventHandler('click', {});
+    await fixture.whenStable();
+
+    expect(location.path()).toBe('/home');
+  });
+});

--- a/lib/models/test-setup.ts
+++ b/lib/models/test-setup.ts
@@ -5,7 +5,7 @@ export class TestSetup<TComponent> {
   readonly dontMock: any[] = [];
   readonly mocks = new Map<any, any>();
   readonly staticMocks = new Map<any, any>();
-  readonly moduleReplacements = new Map<Type<any>, Type<any> | ModuleWithProviders>();
+  readonly moduleReplacements = new Map<Type<any> | ModuleWithProviders, Type<any> | ModuleWithProviders>();
   readonly mockPipes = new Map<PipeTransform | Type<PipeTransform>, Function>(); /* tslint:disable-line ban-types */
   readonly mockCache = new MockCache();
   readonly providers: Provider[] = [];

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -80,7 +80,7 @@ export class Shallow<TTestComponent> {
     return this;
   }
 
-  replaceModule(originalModule: Type<any>, replacementModule: Type<any> | ModuleWithProviders): this {
+  replaceModule(originalModule: Type<any> | ModuleWithProviders, replacementModule: Type<any> | ModuleWithProviders): this {
     this.setup.moduleReplacements.set(originalModule, replacementModule);
     return this;
   }

--- a/lib/tools/mock-module.spec.ts
+++ b/lib/tools/mock-module.spec.ts
@@ -1,0 +1,128 @@
+import { Type, Component, NgModule } from '@angular/core';
+import { getNgModuleAnnotations } from './get-ng-module-annotations';
+import { mockModule, InvalidModuleError } from './mock-module';
+import { TestSetup } from '../models/test-setup';
+import * as _ngMock from './ng-mock';
+import * as _mockProvider from './mock-provider';
+
+@Component({
+  selector: 'foo-component',
+  template: '<div>FOO</div>',
+})
+class FooComponent {}
+
+@Component({
+  selector: 'bar-component',
+  template: '<div>BAR</div>',
+})
+class BarComponent {}
+
+const makeModule = (params: NgModule = {}): Type<any> => {
+  @NgModule(params)
+  class TestModule {}
+  return TestModule;
+};
+
+describe('mockModule', () => {
+  let setup: TestSetup<any>;
+
+  const isMocked = (thing: any) => thing.name.includes('Mock');
+  const isMockOf = (mock: any, thing: any) => mock.original === thing;
+  const makeMock = <TParams extends NgModule>(params: TParams) => {
+    const ngModule = makeModule(params);
+    const mockedModule = mockModule(ngModule, setup);
+    return {
+      ngModule,
+      mockedModule,
+      annotations: getNgModuleAnnotations(mockedModule) as TParams,
+    };
+  };
+
+  beforeEach(() => {
+    const dummyMocker = (thing: any) => class Mock { static original = thing; };
+    spyOn(_ngMock, 'ngMock').and.callFake(dummyMocker);
+    spyOn(_mockProvider, 'mockProvider').and.callFake(dummyMocker);
+    setup = new TestSetup(class Foo {}, class Bar {});
+  });
+
+  it('mocks an imports entry that is an array of modules', () => {
+    const moduleArray = [makeModule(), makeModule()];
+    const result = mockModule(moduleArray, setup);
+
+    expect(result.map(isMocked)).toEqual([true, true]);
+  });
+
+  it('does not mock replacementModules', () => {
+    const original = makeModule();
+    const replacement = makeModule();
+    setup.moduleReplacements.set(original, replacement);
+    const result = mockModule(original, setup);
+
+    expect(result).toBe(replacement);
+  });
+
+  it('does not break apart replacementModules ModuleWithProviders', () => {
+    const original = {ngModule: makeModule(), providers: [class FooClass {}]};
+    const replacement = makeModule();
+    setup.moduleReplacements.set(original, replacement);
+    const result = mockModule(original, setup);
+
+    expect(result).toBe(replacement as any);
+  });
+
+  it('memoizes mocks of modules', () => {
+    const mod = makeModule();
+    expect(mockModule(mod, setup))
+      .toBe(mockModule(mod, setup));
+  });
+
+  it('memoizes mocks of arrays', () => {
+    const mod = [makeModule()];
+    expect(mockModule(mod, setup))
+      .toBe(mockModule(mod, setup));
+  });
+
+  it('memoizes mocks of arrays', () => {
+    const mod = [makeModule()];
+    expect(mockModule(mod, setup))
+      .toBe(mockModule(mod, setup));
+  });
+
+  it('mocks imports', () => {
+    const imports = [class FooModule {}, class BarModule {}];
+    const {annotations} = makeMock({imports});
+
+    expect(isMockOf(annotations.imports, imports)).toBe(true);
+  });
+
+  it('mocks declarations', () => {
+    const declarations = [FooComponent, BarComponent];
+    const {annotations} = makeMock({declarations});
+
+    expect(isMockOf(annotations.declarations, declarations)).toBe(true);
+  });
+
+  it('mocks entryComponents', () => {
+    const entryComponents = [FooComponent, BarComponent];
+    const {annotations} = makeMock({entryComponents});
+
+    expect(isMockOf(annotations.entryComponents, entryComponents)).toBe(true);
+  });
+
+  it('mocks providers', () => {
+    class FooService {}
+    class BarService {}
+    const {annotations} = makeMock({
+      providers: [FooService, BarService]
+    });
+
+    expect(isMockOf(annotations.providers[0], FooService)).toBe(true);
+    expect(isMockOf(annotations.providers[1], BarService)).toBe(true);
+  });
+
+  it('throws an error when module is not a recognized Angular module', () => {
+    const bogusModule = 'NOT A REAL MODULE';
+    expect(() => mockModule(bogusModule as any, setup))
+      .toThrow(new InvalidModuleError(bogusModule));
+  });
+});

--- a/lib/tools/type-checkers.ts
+++ b/lib/tools/type-checkers.ts
@@ -1,29 +1,29 @@
 import { ModuleWithProviders, PipeTransform, Provider, ClassProvider, ExistingProvider, FactoryProvider, ValueProvider, TypeProvider } from '@angular/core';
 import { pipeResolver } from './reflect';
 
-export function isModuleWithProviders(thing: any): thing is ModuleWithProviders {
+export function isModuleWithProviders(provider: any): provider is ModuleWithProviders {
   const key: keyof ModuleWithProviders = 'ngModule';
-  return key in thing;
+  return typeof provider === 'object' && key in provider;
 }
 
 export function isValueProvider(provider: Provider): provider is ValueProvider {
   const key: keyof ValueProvider = 'useValue';
-  return key in provider;
+  return typeof provider === 'object' && key in provider;
 }
 
 export function isExistingProvider(provider: Provider): provider is ExistingProvider {
   const key: keyof ExistingProvider = 'useExisting';
-  return key in provider;
+  return typeof provider === 'object' && key in provider;
 }
 
 export function isFactoryProvider(provider: Provider): provider is FactoryProvider {
   const key: keyof FactoryProvider = 'useFactory';
-  return key in provider;
+  return typeof provider === 'object' && key in provider;
 }
 
 export function isClassProvider(provider: Provider): provider is ClassProvider {
   const key: keyof ClassProvider = 'useClass';
-  return key in provider;
+  return typeof provider === 'object' && key in provider;
 }
 
 export function isTypeProvider(provider: Provider): provider is TypeProvider {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,54 +5,63 @@
   "requires": true,
   "dependencies": {
     "@angular/common": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-6.0.2.tgz",
-      "integrity": "sha512-Yc3NnLGs1ltnDhUCOoMCQMRSkJv/sCv+jKx3uSdrvd8Y55APl2boZhZUK4WphPfWIkpvC7odpiLXAmnVgP6vcw==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-6.0.7.tgz",
+      "integrity": "sha512-MUCCs3FLwqyp5wuvkUTHVGMTd3bNGDxD5IJNvaLgVliGe4r0IlETRXYqyRPs7gdVFPbiJ97P1DUONArj9xL9XA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/compiler": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-6.0.2.tgz",
-      "integrity": "sha512-uKuM7dcTWwcElklT4E/tckp5fnGNUq4wDna3gZWO6fvc7FQK0SUU4l+A6C1d5YdCRgAsv6gxIrk3MxbSF9UwEw==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-6.0.7.tgz",
+      "integrity": "sha512-J9I2U4NiWIBXl0ZOJkBW5G7xXhphggSirTwFLD4yKCTeJXgyldZytJZRkDUx1uouZtI2/PycvaOZoRr85N67AA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/core": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-6.0.2.tgz",
-      "integrity": "sha512-+ahJofKZFyaq0kLhKUOCa3Fo4WQ4mkMmYRqwFjKgjPupzPgMh0FkBsojuP1WiBd5KTIkv7U8B4sTziUxRDrKgg==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-6.0.7.tgz",
+      "integrity": "sha512-aZ0NvbYsMGqg0zUu7+9vuDxnGzwe++RsBBhlwHZHz1ZZwJmU6VJhUhaI+MuKC7rHyFFr9vUxvJ7ilhGaK2+J7A==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/forms": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-6.0.2.tgz",
-      "integrity": "sha512-Oc234cLjTj1tx2gF/nS/TIC3Auc+LCyC8H6GYqTxXQUyZQeGHqUptvDQz3KwM9Num3EKFUr9J2yzGPnz6lZVmQ==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-6.0.7.tgz",
+      "integrity": "sha512-bFRdWxLmTiG7z0yZaq22oBHTgVSpJwUJEbZ5ieu21JqTgIDYne+YR/xCJrPj+P2S5NDlEK84g/4y4GoNt/thhQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/platform-browser": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-6.0.2.tgz",
-      "integrity": "sha512-iMBHckhknJ8Wfw9ZVloiw0WPZDtzQFLE2e7D42of7SgXuHloStXUchb0qLr6ZTZwTY0oBPSvDKgJJVmEjZUZvw==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-6.0.7.tgz",
+      "integrity": "sha512-CASH1CDr2DD+aBrWN9qpDDFTI3H6p/oqH23h28bEV+LZl7F57r4sj8KXKgaE+mcrOFRQqXTAlPoq3hRCLmhtVA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-6.0.2.tgz",
-      "integrity": "sha512-g1EC0wIWd4OhcEvUnisTfp3y0eMAXgXbACdtgsrozG//xzyqiRFUnBTYTAP4ecninCEltyZYK7EBGfzp8KwQjw==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-6.0.7.tgz",
+      "integrity": "sha512-8G45A9w8UJvX3vPEHqeJHt/sd0zu6w1M+rsnOCo78r35SjsLbrmDNhc4VkLZFJ+iNjgPWtNtdpeXQqtTHE46yw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "@angular/router": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-6.0.7.tgz",
+      "integrity": "sha512-KuQBeIgfiwV3bLafepMhYVJQIAF8cTckCudFh5Z0OqckJgGsWSgtvEdtBctPi+lzt7OQBi7Ym2rOv3X0dOvu0Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "definition": "dist/index"
   },
   "scripts": {
-    "clean": "rm -rf dist coverage",
+    "clean": "rm -rf dist",
     "lint": "tslint -t stylish --project tsconfig.json",
     "lint:fix": "npm run lint -- --fix",
     "build": "npm run clean && tsc",

--- a/package.json
+++ b/package.json
@@ -55,11 +55,12 @@
   },
   "devDependencies": {
     "@angular/common": "6.x",
+    "@angular/compiler": "6.x",
     "@angular/core": "6.x",
     "@angular/forms": "6.x",
-    "@angular/compiler": "6.x",
     "@angular/platform-browser": "6.x",
     "@angular/platform-browser-dynamic": "6.x",
+    "@angular/router": "6.x",
     "@types/jasmine": "^2.5.53",
     "@types/node": "^8.0.17",
     "core-js": "^2.5.6",


### PR DESCRIPTION
There was an issue that caused Shallow to mock providers on `ModuleWithProviders` replacement modules.

For example, using:
```typescript
shallow.replaceModule(
  FooModule,
  { ngModule: FooTestModule, providers: [TestFooService] }
);
```
Would result in the providers array being mocked but this is never necessary when we replace modules. As a work-around, you could use `.dontMock` on the providers but it's a weird looking and obvious hack around this bug.

After this fix, nothing in a replacement module is ever mocked.