### PR TITLE
feat: Support testing structural directives

### DIFF
--- a/lib/examples/component-with-routing.spec.ts
+++ b/lib/examples/component-with-routing.spec.ts
@@ -46,7 +46,6 @@ describe('component with routing', () => {
       //////////////////////////
       // These are good candidates for global setup
       // using `neverMock` and `alwaysProvide`
-      .dontMock(routerModuleRef)
       .provide({provide: APP_BASE_HREF, useValue: '/'})
       .dontMock(APP_BASE_HREF)
       ///////////////////////////

--- a/lib/examples/structural-directive.spec.ts
+++ b/lib/examples/structural-directive.spec.ts
@@ -1,0 +1,41 @@
+import { Input, Directive, NgModule, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+@Directive({ selector: '[showIfFoo]' })
+export class ShowIfFooDirective {
+  constructor(private readonly templateRef: TemplateRef<any>, private readonly viewContainer: ViewContainerRef) {}
+
+  @Input() set showIfFoo(value: string) {
+    this.viewContainer.clear();
+    if (value === 'foo') {
+      this.viewContainer.createEmbeddedView(this.templateRef);
+    }
+  }
+}
+
+@NgModule({
+  declarations: [ShowIfFooDirective],
+})
+class MyModule {}
+//////////////////////////
+
+describe('Structural Directive', () => {
+  let shallow: Shallow<ShowIfFooDirective>;
+
+  beforeEach(() => {
+    shallow = new Shallow(ShowIfFooDirective, MyModule);
+  });
+
+  it('shows content when value is "foo"', async () => {
+    const {element} = await shallow.render('<div *showIfFoo="\'foo\'">Show Me</div>');
+
+    expect(element.nativeElement.textContent).toBe('Show Me');
+  });
+
+  it('does not show content when value is not "foo"', async () => {
+    const {element} = await shallow.render('<div *showIfFoo="\'bar\'">Show Me</div>');
+
+    expect(element).not.toBeDefined();
+  });
+});

--- a/lib/models/renderer.spec.ts
+++ b/lib/models/renderer.spec.ts
@@ -1,6 +1,7 @@
 import { Input, Output, OnInit, Component, EventEmitter, NgModule } from '@angular/core';
 import { Renderer, InvalidStaticPropertyMockError } from './renderer';
 import { TestSetup } from './test-setup';
+import { NgIf } from '@angular/common';
 
 class TestUtility { // tslint:disable-line no-unnecessary-class
   static readonly staticNumber = 123;
@@ -182,6 +183,29 @@ describe('Renderer', () => {
       });
 
       expect(find('div').nativeElement.textContent).toBe('');
+    });
+  });
+
+  describe('structural directives', () => {
+    it('element is the first child element when testing a structural directive', async () => {
+      const myRenderer = new Renderer(new TestSetup(NgIf, TestModule));
+      const {element} = await myRenderer.render('<b *ngIf="true"></b>');
+
+      expect(element.nativeElement.tagName).toBe('B');
+    });
+
+    it('element is undefined when the structural directive does not render an element', async () => {
+      const myRenderer = new Renderer(new TestSetup(NgIf, TestModule));
+      const {element} = await myRenderer.render('<b *ngIf="false"></b>');
+
+      expect(element).not.toBeDefined();
+    });
+
+    it('instance is the directive instance when testing a structural directive', async () => {
+      const myRenderer = new Renderer(new TestSetup(NgIf, TestModule));
+      const {instance} = await myRenderer.render('<b *ngIf="true"></b>');
+
+      expect(instance instanceof NgIf).toBe(true);
     });
   });
 });

--- a/lib/models/rendering.spec.ts
+++ b/lib/models/rendering.spec.ts
@@ -1,5 +1,6 @@
-import { Component, Directive, Type } from '@angular/core';
+import { Component, DebugElement, Directive, Type } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { Rendering } from './rendering';
 import { TestSetup } from './test-setup';
@@ -58,6 +59,8 @@ class OtherComponent {}
 describe('Rendering', () => {
   let testSetup: TestSetup<OuterComponent>;
   let fixture: ComponentFixture<TestHostComponent>;
+  let instance: ComponentToMock;
+  let element: DebugElement;
   let MockedComponent: Type<ComponentToMock>;
   let MockedDirective: Type<DirectiveToMock>;
 
@@ -81,72 +84,74 @@ describe('Rendering', () => {
     }).compileComponents().then(() => {
       fixture = TestBed.createComponent(TestHostComponent);
       fixture.detectChanges();
+      element = fixture.debugElement.query(By.directive(OuterComponent));
+      instance = element.componentInstance;
     });
   });
 
   describe('find', () => {
     it('can be destructured', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(() => find('some-css-selector')).not.toThrowError();
     });
 
     it('throws an error when used to find the test component by CSS', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(() => find('outer')).toThrow();
     });
 
     it('does not throw an error when used to find an inner element of the test component', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(() => find('div.outer')).not.toThrow();
     });
 
     it('throws an error when used to find the test component by Directive', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(() => find(OuterComponent)).toThrow();
     });
 
     it('can find things by CSS', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(find('inner')).toHaveFound(1);
     });
 
     it('can find by Component', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(find(InnerComponent)).toHaveFound(1);
     });
 
     it('finds by mocked Components', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(find(ComponentToMock)).toHaveFound(1);
     });
 
     it('can find by Directive', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(find(InnerComponent)).toHaveFound(1);
     });
 
     it('finds by mocked directives', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(find(DirectiveToMock)).toHaveFound(1);
     });
 
     it('returns an empty query match when no matches found', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(find('will-not-be-found')).toHaveFound(0);
     });
 
     it('returns a QueryMatch when a match is found', () => {
-      const {find} = new Rendering(fixture, {}, testSetup);
+      const {find} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(find('inner')).toHaveFound(1);
       expect(find('inner').nativeElement).toBeDefined();
@@ -155,25 +160,25 @@ describe('Rendering', () => {
 
   describe('findComponent', () => {
     it('can be destructured', () => {
-      const {findComponent} = new Rendering(fixture, {}, testSetup);
+      const {findComponent} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(() => findComponent(InnerComponent)).not.toThrow();
     });
 
     it('finds components', () => {
-      const {findComponent} = new Rendering(fixture, {}, testSetup);
+      const {findComponent} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(findComponent(InnerComponent) instanceof InnerComponent).toBe(true);
     });
 
     it('finds mocked components', () => {
-      const {findComponent} = new Rendering(fixture, {}, testSetup);
+      const {findComponent} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(findComponent(ComponentToMock) instanceof MockedComponent).toBe(true);
     });
 
     it('finds multiple components', () => {
-      const {findComponent} = new Rendering(fixture, {}, testSetup);
+      const {findComponent} = new Rendering(fixture, element, instance, {}, testSetup);
 
       const found = findComponent(OtherComponent);
       expect(found).toHaveFound(2);
@@ -183,25 +188,25 @@ describe('Rendering', () => {
 
   describe('findDirective', () => {
     it('can be destructured', () => {
-      const {findDirective} = new Rendering(fixture, {}, testSetup);
+      const {findDirective} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(() => findDirective(TestDirective)).not.toThrow();
     });
 
     it('finds directives', () => {
-      const {findDirective} = new Rendering(fixture, {}, testSetup);
+      const {findDirective} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(findDirective(TestDirective) instanceof TestDirective).toBe(true);
     });
 
     it('finds mocked directives', () => {
-      const {findDirective} = new Rendering(fixture, {}, testSetup);
+      const {findDirective} = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(findDirective(DirectiveToMock) instanceof MockDirective(DirectiveToMock)).toBe(true);
     });
 
     it('finds multiple directives', () => {
-      const {findDirective} = new Rendering(fixture, {}, testSetup);
+      const {findDirective} = new Rendering(fixture, element, instance, {}, testSetup);
 
       const found = findDirective(OtherDirective);
       expect(found).toHaveFound(2);
@@ -211,7 +216,7 @@ describe('Rendering', () => {
 
   describe('get', () => {
     it('returns the result of TestBed.get', () => {
-      const {get} = new Rendering(fixture, {}, testSetup);
+      const {get} = new Rendering(fixture, element, instance, {}, testSetup);
       spyOn(TestBed, 'get').and.returnValue('foo');
 
       class QueryClass {}
@@ -222,7 +227,7 @@ describe('Rendering', () => {
   describe('bindings object', () => {
     it('is returned', () => {
       const inputBindings = {};
-      const {bindings} = new Rendering(fixture, inputBindings, testSetup);
+      const {bindings} = new Rendering(fixture, element, instance, inputBindings, testSetup);
 
       expect(bindings).toBe(inputBindings);
     });
@@ -230,9 +235,9 @@ describe('Rendering', () => {
 
   describe('test component instance', () => {
     it('is returned', () => {
-      const {instance} = new Rendering(fixture, {}, testSetup);
+      const rendering = new Rendering(fixture, element, instance, {}, testSetup);
 
-      expect(instance instanceof OuterComponent).toBe(true);
+      expect(rendering.instance).toBe(instance);
     });
   });
 });

--- a/lib/models/rendering.ts
+++ b/lib/models/rendering.ts
@@ -11,20 +11,13 @@ export interface RenderOptions<TBindings> {
 }
 
 export class Rendering<TComponent, TBindings> {
-  readonly element: DebugElement;
-  readonly instance: TComponent;
-
-  constructor(public fixture: ComponentFixture<any>, public bindings: TBindings, private readonly _setup: TestSetup<TComponent>) {
-    this.element = this.fixture.componentInstance instanceof this._setup.testComponent
-      ? this.fixture.debugElement
-      : this.fixture.debugElement.query(By.directive(this._setup.testComponent));
-
-    if (!this.element) {
-      throw new Error(`${this._setup.testComponent.name} was not found in test template`);
-    }
-
-    this.instance = this.element.injector.get<TComponent>(this._setup.testComponent);
-  }
+  constructor(
+    public readonly fixture: ComponentFixture<any>,
+    public readonly element: DebugElement,
+    public readonly instance: TComponent,
+    public readonly bindings: TBindings,
+    private readonly _setup: TestSetup<TComponent>
+  ) {}
 
   /////////////////////////////////////////////////////////////////////////////
   // The following methods MUST be arrow functions so they can be deconstructured


### PR DESCRIPTION
Support for testing Structural Directives:
Fixes #47 

The general idea here is that when testing structural directives, you may simply test for the existence (or not) of the `Rendering#element` property. 

Positive test case (just what you'd expect):
```typescript
  it('shows content when value is "foo"', async () => {
    const {element} = await shallow.render(`<div *showIfFoo="'foo'">Show Me</div>`);

    expect(element.nativeElement.textContent).toBe('Show Me');
    /* -- or simply -- */
    expect(element).toBeDefined();
  });

```

Negative test case:
```typescript
  it('does not show content when value is not "foo"', async () => {
    const {element} = await shallow.render(`<div *showIfFoo="'bar'">Show Me</div>`);

    expect(element).not.toBeDefined();
  });
```