### PR TITLE
feat: Allow mocking component instance properties

### DIFF
--- a/lib/examples/component-with-content-child.spec.ts
+++ b/lib/examples/component-with-content-child.spec.ts
@@ -1,0 +1,59 @@
+import { ContentChild, Component, NgModule, AfterContentInit } from '@angular/core';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+@Component({
+  selector: 'list-item',
+  template: '<li [class.bold]="active"><ng-content></ng-content></li>',
+})
+class ListItemComponent {
+  protected active = false;
+  activate() {
+    this.active = true;
+  }
+  deactivate() {
+    this.active = false;
+  }
+}
+
+@Component({
+  selector: 'list-container',
+  template: '<ul><ng-content></ng-content></ul>',
+})
+class ListContainerComponent implements AfterContentInit {
+  @ContentChild('active') listItem: ListItemComponent;
+  ngAfterContentInit() {
+    if (this.listItem) {
+      this.listItem.activate();
+    }
+  }
+}
+
+@NgModule({
+  declarations: [ListContainerComponent, ListItemComponent]
+})
+class ListModule {}
+//////////////////////////
+
+describe('template content child', () => {
+  let shallow: Shallow<ListContainerComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(ListContainerComponent, ListModule);
+  });
+
+  it('activates the first item in the list', async () => {
+    const {findComponent} = await shallow
+      .mock(ListItemComponent, {activate: () => undefined})
+      .render(`
+        <list-container>
+          <list-item #active>Foo</list-item>
+          <list-item>Bar</list-item>
+        </list-container>
+      `);
+
+    const listItems = findComponent(ListItemComponent);
+    expect(listItems[0].activate).toHaveBeenCalled();
+    expect(listItems[1].activate).not.toHaveBeenCalled();
+  });
+});

--- a/lib/examples/template-with-hash-references.spec.ts
+++ b/lib/examples/template-with-hash-references.spec.ts
@@ -1,0 +1,60 @@
+import { Input, Component, NgModule } from '@angular/core';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+@Component({
+  selector: 'list-container',
+  template: '<ul><ng-content *ngIf="!collapsed"></ng-content></ul>',
+})
+class ListContainerComponent {
+  protected collapsed = false;
+
+  collapse() {
+    this.collapsed = true;
+  }
+  expand() {
+    this.collapsed = false;
+  }
+}
+
+@Component({
+  selector: 'list-item',
+  template: '<li [class.bold]="bold"><ng-content></ng-content></li>',
+})
+class ListItemComponent {
+  @Input() bold = false;
+}
+
+@Component({
+  selector: 'awesome-list',
+  template: `
+    <list-container #container>
+      <list-item (click)="container.collapse()">Chuck Norris</list-item>
+    </list-container>
+  `,
+})
+class AwesomeListComponent { }
+
+@NgModule({
+  declarations: [ListContainerComponent, ListItemComponent, AwesomeListComponent]
+})
+class ListModule {}
+//////////////////////////
+
+describe('template hash references', () => {
+  let shallow: Shallow<AwesomeListComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(AwesomeListComponent, ListModule);
+  });
+
+  it('collapses the parent when clicked', async () => {
+    const {find, findComponent} = await shallow
+      .mock(ListContainerComponent, {collapse: () => undefined})
+      .render();
+
+    const container = findComponent(ListContainerComponent);
+    find(ListItemComponent).triggerEventHandler('click', {});
+    expect(container.collapse).toHaveBeenCalled();
+  });
+});

--- a/lib/tools/ng-mock.spec.ts
+++ b/lib/tools/ng-mock.spec.ts
@@ -7,7 +7,9 @@ import * as ngMocksLib from 'ng-mocks';
 @Component({
   template: '<label>foo</label>'
 })
-class FooComponent {}
+class FooComponent {
+  doFoo() { return 'doFoo'; }
+}
 
 @Directive({
   selector: '[foo]'
@@ -54,6 +56,33 @@ describe('ng-mock', () => {
     const mocked = ngMock(FooComponent, testSetup);
 
     expect(mocked).toBe('MOCKED' as any);
+  });
+
+  describe('components with mocks', () => {
+    it('adds stubs to components', () => {
+      testSetup.mocks.set(FooComponent, {doFoo: () => 'mocked doFoo'});
+      const MockedFoo = ngMock(FooComponent, testSetup);
+      const foo = new MockedFoo();
+
+      expect(foo.doFoo()).toBe('mocked doFoo');
+    });
+
+    it('spys on component stubs', () => {
+      testSetup.mocks.set(FooComponent, {doFoo: () => 'mocked doFoo'});
+      const MockedFoo = ngMock(FooComponent, testSetup);
+      const foo = new MockedFoo();
+
+      foo.doFoo();
+      expect(foo.doFoo).toHaveBeenCalled(); // doFoo should be a spy
+    });
+
+    it('uses MockOf* in the mocked component class name', () => {
+      testSetup.mocks.set(FooComponent, {});
+      const MockedFoo = ngMock(FooComponent, testSetup);
+      const foo = new MockedFoo();
+
+      expect(foo.constructor.name).toBe('MockOfFooComponent');
+    });
   });
 
   it('mocks a directive', () => {


### PR DESCRIPTION
Addresses #52 
### Allow mocking component instance properties

When a component is written using the template-hash pattern, we sometimes need to mock methods on these components when we use them. For example:

in `MyComponent` we may render something like this:
```xml
<list-container #container>
  <list-item (click)="container.collapse()">Collapse the parent!</list-item>
</list-container>
```

Shallow will provide us a mock of `list-container` and `list-item`, but if we want to write a test that ensures we hooked up the `click` handler correctly, we'll have to call the `collapse` method on the `list-container` component so we'll need to mock that method out. Before this change, Shallow would not apply mock properties to component instances but now we can.

```typescript
const {find} = await shallow
  .mock(ListContainerComponent, {collapse: () => undefnied})
  .render();
find('list-item').triggerEventHandler('click', {});
expect(findComponent(ListContainerComponent).collapse).toHaveBeenCalled();
```
