### PR TITLE
feat: Add support for `Shallow#import` and `Shallow.alwaysImport`

### DIFF
--- a/lib/examples/using-always-import.spec.ts
+++ b/lib/examples/using-always-import.spec.ts
@@ -1,0 +1,57 @@
+import { Injectable, Component, NgModule } from '@angular/core';
+import { Shallow } from '../shallow';
+
+/////// Global Service Module ///////
+// This service is provided globally via a ServiceModule
+@Injectable()
+class RedService {
+  color() { return 'RED'; }
+}
+
+@NgModule({ providers: [RedService] })
+class ServiceModule {}
+/////////////////////////////////////
+
+////// Module Setup //////
+@Component({
+  selector: 'color-label',
+  template: '<label>{{redService.color()}}</label>',
+})
+class ColorLabelComponent {
+  constructor(public redService: RedService) {}
+}
+
+@NgModule({ declarations: [ColorLabelComponent] })
+class ColorModule {}
+//////////////////////////
+
+//////////////////////////////////////////////////////////////////
+// Somewhere in your top-level test setup (maybe the karma shim?)
+// This will import (and mock!) the ServiceModule in ALL shallow test modules
+Shallow.alwaysImport(ServiceModule)
+       .neverMock(RedService); // Without this line, the RedService will be auto-mocked
+//////////////////////////////////////////////////////////////////
+
+describe('alwaysImport', () => {
+  let shallow: Shallow<ColorLabelComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(ColorLabelComponent, ColorModule);
+  });
+
+  it('Uses the color from the RedService', async () => {
+    const {element} = await shallow.render('<color-label></color-label>');
+
+    // Using the actual service response here (not mocked)
+    expect(element.nativeElement.innerText).toBe('RED');
+  });
+
+  it('Uses the color from the mocked RedService', async () => {
+    const {element} = await shallow
+      // User mocks always override things that are 'neverMocked'
+      .mock(RedService, {color: () => 'MOCKED VALUE'})
+      .render('<color-label></color-label>');
+
+    expect(element.nativeElement.innerText).toBe('MOCKED VALUE');
+  });
+});

--- a/lib/models/test-setup.ts
+++ b/lib/models/test-setup.ts
@@ -9,6 +9,7 @@ export class TestSetup<TComponent> {
   readonly mockPipes = new Map<PipeTransform | Type<PipeTransform>, Function>(); /* tslint:disable-line ban-types */
   readonly mockCache = new MockCache();
   readonly providers: Provider[] = [];
+  readonly imports: (Type<any> | ModuleWithProviders)[] = [];
 
   constructor(
     public readonly testComponent: Type<TComponent>,

--- a/lib/shallow.spec.ts
+++ b/lib/shallow.spec.ts
@@ -61,6 +61,16 @@ describe('Shallow', () => {
     });
   });
 
+  describe('alwaysImport', () => {
+    it('adds modules to setup.imports on construction', () => {
+      @NgModule({}) class MyModule {}
+      Shallow.alwaysImport(MyModule);
+      const shallow = new Shallow(TestComponent, TestModule);
+
+      expect(shallow.setup.imports).toContain(MyModule);
+    });
+  });
+
   describe('alwaysMock', () => {
     it('items are automatically added to setup.mock on construction', () => {
       class MyService {
@@ -123,6 +133,16 @@ describe('Shallow', () => {
         .provide(MyService);
 
       expect(shallow.setup.providers).toContain(MyService);
+    });
+  });
+
+  describe('import', () => {
+    it('adds to the setup.imports array', () => {
+      @NgModule({}) class MyModule {}
+      const shallow = new Shallow(TestComponent, TestModule)
+        .import(MyModule);
+
+      expect(shallow.setup.imports).toContain(MyModule);
     });
   });
 

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -31,14 +31,20 @@ export class Shallow<TTestComponent> {
   private static readonly _alwaysMock = new Map<Type<any> | InjectionToken<any>, any>();
   static alwaysMock<TProvider>(thing: Type<TProvider> | InjectionToken<TProvider>, stubs: Partial<TProvider>): typeof Shallow {
     const mock = Shallow._alwaysMock.get(thing) || {};
-    Shallow._alwaysMock.set(thing, {...mock, ...stubs as object});
+    this._alwaysMock.set(thing, {...mock, ...stubs as object});
     return Shallow;
   }
 
   // Always replace one module with another replacement module.
   private static readonly _alwaysReplaceModule = new Map<Type<any>, Type<any> | ModuleWithProviders>();
-  static alwaysReplaceModule(originalModule: Type<any>, replacementModule: Type<any>): typeof Shallow {
-    Shallow._alwaysReplaceModule.set(originalModule, replacementModule);
+  static alwaysReplaceModule(originalModule: Type<any>, replacementModule: Type<any> | ModuleWithProviders): typeof Shallow {
+    this._alwaysReplaceModule.set(originalModule, replacementModule);
+    return Shallow;
+  }
+
+  private static readonly _alwaysImport: (Type<any> | ModuleWithProviders)[] = [];
+  static alwaysImport(...imports: (Type<any> | ModuleWithProviders)[]) {
+    this._alwaysImport.push(...imports);
     return Shallow;
   }
 
@@ -46,6 +52,7 @@ export class Shallow<TTestComponent> {
     this.setup = new TestSetup(testComponent, testModule);
     this.setup.dontMock.push(testComponent, ...Shallow._neverMock);
     this.setup.providers.push(...Shallow._alwaysProvide);
+    this.setup.imports.push(...Shallow._alwaysImport);
     Shallow._alwaysMock.forEach((value, key) => this.setup.mocks.set(key, value));
     Shallow._alwaysReplaceModule.forEach((value, key) => this.setup.moduleReplacements.set(key, value));
   }
@@ -82,6 +89,11 @@ export class Shallow<TTestComponent> {
 
   replaceModule(originalModule: Type<any> | ModuleWithProviders, replacementModule: Type<any> | ModuleWithProviders): this {
     this.setup.moduleReplacements.set(originalModule, replacementModule);
+    return this;
+  }
+
+  import(...imports: (Type<any> | ModuleWithProviders)[]) {
+    this.setup.imports.push(...imports);
     return this;
   }
 

--- a/lib/tools/copy-test-module.ts
+++ b/lib/tools/copy-test-module.ts
@@ -17,7 +17,7 @@ export function copyTestModule<TComponent>(setup: TestSetup<TComponent>): NgModu
   const ngModule = getNgModuleAnnotations(mod);
 
   return {
-    imports: ngMock(ngModule.imports, setup),
+    imports: ngMock([...ngModule.imports, ...setup.imports], setup),
     declarations: ngMock(ngModule.declarations, setup),
     entryComponents: ngMock(ngModule.entryComponents, setup),
     providers: [


### PR DESCRIPTION
Suggested in #59, there are good uses for providing a way to add module imports to an existing module.

This can now be done simply by using `.import(ModuleToImport)`:
```typescript
beforeEach(() => {
  shallow = new Shallow(MyComponent, ComponentModule).import(BrowserAnimationsModule);
});
```

Or, if you want to import it for all specs globally:

```typescript
Shallow.alwaysImport(BrowserAnimationsModule);
```

Thanks @kylecannon for helping iron out the use case for this.