### PR TITLE
fix: Match replacementModules on ModuleWithProviders#ngModule

### DIFF
--- a/lib/examples/component-with-routing.spec.ts
+++ b/lib/examples/component-with-routing.spec.ts
@@ -27,11 +27,8 @@ const routes: Routes = [
   {path: 'home', component: class DummyComponent {}}
 ];
 
-// You probabaly want to export this ref from your module
-// so we can give Shallow specs access to it too.
-const routerModuleRef = RouterModule.forRoot(routes);
 @NgModule({
-  imports: [routerModuleRef],
+  imports: [RouterModule.forRoot(routes)],
   providers: [{provide: APP_BASE_HREF, useValue: '/'}],
   declarations: [GoHomeLinkComponent],
 })
@@ -50,7 +47,7 @@ describe('component with routing', () => {
       .dontMock(APP_BASE_HREF)
       ///////////////////////////
       .replaceModule(
-        routerModuleRef,
+        RouterModule,
         RouterTestingModule.withRoutes(routes)
       );
   });

--- a/lib/tools/mock-module.spec.ts
+++ b/lib/tools/mock-module.spec.ts
@@ -70,6 +70,16 @@ describe('mockModule', () => {
     expect(result).toBe(replacement as any);
   });
 
+  it('looks for a match on ModuleWithProviders#ngModule', () => {
+    const originalModule = makeModule();
+    const moduleWithProviders = {ngModule: originalModule, providers: [class FooClass {}]};
+    const replacement = makeModule();
+    setup.moduleReplacements.set(originalModule, replacement);
+    const result = mockModule(moduleWithProviders, setup);
+
+    expect(result).toBe(replacement as any);
+  });
+
   it('memoizes mocks of modules', () => {
     const mod = makeModule();
     expect(mockModule(mod, setup))

--- a/lib/tools/mock-module.ts
+++ b/lib/tools/mock-module.ts
@@ -21,7 +21,7 @@ export function mockModule<TModule extends AnyNgModule>(mod: TModule, setup: Tes
     return cached;
   }
 
-  const replacementModule = setup.moduleReplacements.get(mod as any);
+  const replacementModule = setup.moduleReplacements.get(mod as any) || setup.moduleReplacements.get((mod as any).ngModule);
   if (replacementModule) {
     return setup.mockCache.add(mod, replacementModule) as TModule;
   }


### PR DESCRIPTION
Address some difficulties with mocking modules from #60 

I think with this change, mocking the RouterModule will be much easier and intuitive.

```typescript
shallow.replaceModule(RouterModule, RouterTestingModule.withRoutes(testRoutes));
```