### PR TITLE
fix: Fix error when trying to mock the RouterModule

### DIFF
--- a/lib/examples/component-with-content-child.spec.ts
+++ b/lib/examples/component-with-content-child.spec.ts
@@ -47,7 +47,7 @@ describe('template content child', () => {
       .mock(ListItemComponent, {activate: () => undefined})
       .render(`
         <list-container>
-          <list-item #active>Foo</list-item>
+          <list-item>Foo</list-item>
           <list-item>Bar</list-item>
         </list-container>
       `);

--- a/lib/tools/ng-mock.ts
+++ b/lib/tools/ng-mock.ts
@@ -12,7 +12,7 @@ export type NgMockable = AngularModule | Type<any> | Type<PipeTransform> | any[]
 const fixEmptySelector = (thing: Type<any>, mock: Type<any>) => {
   const annotations = directiveResolver.resolve(thing);
   if (!annotations.selector) {
-    TestBed.overrideDirective(mock, { add: { selector: `__${mock.name}-selector` } });
+    TestBed.overrideDirective(mock, { add: { selector: `.__${mock.name}-selector` } });
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3493,9 +3493,9 @@
       "dev": true
     },
     "ng-mocks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ng-mocks/-/ng-mocks-7.0.1.tgz",
-      "integrity": "sha512-iq4H7jFqf8hiCFDfzzPDkdSXcNSlJvEGnrpQ6JL16+mm/3LrRNjch5fkXFA3H4qoXVxw/D11WwtqV1Mgus5xsQ=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ng-mocks/-/ng-mocks-7.2.0.tgz",
+      "integrity": "sha512-ewKXwT5+kSL1gulxcHY7hB6ebqb7LAjywhxvrz5UYAQNi/10Xw1cIKIasTZfu7SuCdcA40pgCqvHqjOPTD91cg=="
     },
     "nopt": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@angular/platform-browser": ">=5.x <=7.x"
   },
   "dependencies": {
-    "ng-mocks": "^7.0.1"
+    "ng-mocks": "^7.2.0"
   },
   "devDependencies": {
     "@angular/common": "^6.1.10",


### PR DESCRIPTION
Fix for #81 and various other issues involving mocking of the Angular `RouterModule`.