### PR TITLE
feat: Allow expectations on an `outputs` object instead of instance

### DIFF
--- a/build-with-supported-angluars.js
+++ b/build-with-supported-angluars.js
@@ -10,7 +10,7 @@ const VERSIONS = {
     packages: {
       'rxjs': '5.5.5',
       'zone.js': '0.8.20',
-      'typescript': '2.7.x',
+      'typescript': '2.8.x', // This is wrong for NG5, but TS 2.7 lacks conditional types so #yolo
     }
   },
   '6': {

--- a/lib/examples/using-no-template-render.spec.ts
+++ b/lib/examples/using-no-template-render.spec.ts
@@ -27,20 +27,20 @@ describe('No-Template Rendering', () => {
   });
 
   it('displays and tracks the name', async () => {
-    const {find, instance} = await shallow.render({
+    const {find, outputs} = await shallow.render({
       bind: { name: 'Chuck Norris' }
     });
     const label = find('label');
     label.nativeElement.click();
 
     expect(label.nativeElement.textContent).toBe('Chuck Norris');
-    expect(instance.select.emit).toHaveBeenCalledWith('Chuck Norris');
+    expect(outputs.select.emit).toHaveBeenCalledWith('Chuck Norris');
   });
 
   it('uses the default name', async () => {
-    const {find, instance} = await shallow.render();
+    const {find, outputs} = await shallow.render();
 
     find('label').nativeElement.click();
-    expect(instance.select.emit).toHaveBeenCalledWith('DEFAULT NAME');
+    expect(outputs.select.emit).toHaveBeenCalledWith('DEFAULT NAME');
   });
 });

--- a/lib/models/rendering.spec.ts
+++ b/lib/models/rendering.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, Directive, Type } from '@angular/core';
+import { Component, DebugElement, Directive, EventEmitter, Output, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent, MockDirective } from 'ng-mocks';
@@ -36,7 +36,10 @@ class OtherDirective {}
     </div>
   `,
 })
-class OuterComponent {}
+class OuterComponent {
+  @Output() markedAsOutput = new EventEmitter<string>();
+  notMarkedAsOutput = new EventEmitter<string>();
+}
 
 @Component({
   selector: 'inner',
@@ -59,7 +62,7 @@ class OtherComponent {}
 describe('Rendering', () => {
   let testSetup: TestSetup<OuterComponent>;
   let fixture: ComponentFixture<TestHostComponent>;
-  let instance: ComponentToMock;
+  let instance: OuterComponent;
   let element: DebugElement;
   let MockedComponent: Type<ComponentToMock>;
   let MockedDirective: Type<DirectiveToMock>;
@@ -238,6 +241,14 @@ describe('Rendering', () => {
       const rendering = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(rendering.instance).toBe(instance);
+    });
+  });
+
+  describe('outputs', () => {
+    it('returns properties that are eventEmitters', () => {
+      const rendering = new Rendering(fixture, element, instance, {}, testSetup);
+
+      expect(rendering.outputs);
     });
   });
 });

--- a/lib/models/rendering.ts
+++ b/lib/models/rendering.ts
@@ -1,6 +1,7 @@
-import { DebugElement, Type } from '@angular/core';
+import { DebugElement, EventEmitter, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { outputProxy, PickByType } from '../tools/output-proxy';
 import { createQueryMatch, QueryMatch } from './query-match';
 import { TestSetup } from './test-setup';
 
@@ -49,4 +50,6 @@ export class Rendering<TComponent, TBindings> {
   }
 
   readonly get = <TClass>(queryClass: Type<TClass>): TClass => TestBed.get(queryClass);
+
+  readonly outputs: PickByType<TComponent, EventEmitter<any>> = outputProxy(this.instance);
 }

--- a/lib/tools/output-proxy.spec.ts
+++ b/lib/tools/output-proxy.spec.ts
@@ -1,0 +1,45 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { outputProxy, PropertyNotAnEventEmitterError, PropertyNotMarkedAsOutputError } from './output-proxy';
+
+describe('outputProxy', () => {
+  @Component({
+    selector: 'Foo',
+    template: '<h1/>',
+  })
+  class FooComponent {
+    @Output() normalOutput = new EventEmitter<string>();
+    @Output() notAnEventEmitter = 'foo';
+    @Output('renamed') renamedOutput = new EventEmitter<string>();
+    notMarkedAsOutput = new EventEmitter<string>();
+  }
+  const component = new FooComponent();
+  const outputs = outputProxy(component);
+
+  it('allows access to eventEmitters that are marked as @Output', () => {
+    expect(outputs.normalOutput)
+      .toBe(component.normalOutput);
+  });
+
+  it('works with renamed outputs', () => {
+    expect(outputs.renamedOutput)
+      .toBe(component.renamedOutput);
+  });
+
+  it('throws an error if the property is not an EventEmitter', () => {
+    try {
+      String((outputs as any).notAnEventEmitter);
+      fail('should have thrown an error');
+    } catch (e) {
+      expect(e instanceof PropertyNotAnEventEmitterError).toBe(true);
+    }
+  });
+
+  it('throws an error if the property is not marked as @Output', () => {
+    try {
+      String(outputs.notMarkedAsOutput);
+      fail('should have thrown an error');
+    } catch (e) {
+      expect(e instanceof PropertyNotMarkedAsOutputError).toBe(true);
+    }
+  });
+});

--- a/lib/tools/output-proxy.ts
+++ b/lib/tools/output-proxy.ts
@@ -1,0 +1,59 @@
+import { EventEmitter } from '@angular/core';
+import { CustomError } from '../models/custom-error';
+import { directiveResolver } from './reflect';
+
+const className = (object: any) => (
+    object
+    && object.constructor
+    && object.constructor.name
+  )
+  || '<UnknownClass>';
+
+export type KeysOfType<TObject, TPropertyType> = {
+  [K in keyof TObject]: TObject[K] extends TPropertyType ? K : never;
+}[keyof TObject];
+
+export type PickByType<TObject, TPropertyType> = Pick<TObject, KeysOfType<TObject, TPropertyType>>;
+
+export class PropertyNotMarkedAsOutputError extends CustomError {
+  constructor(key: string | symbol | number, component: any) {
+    super(
+      `${key} is not marked with the @Output() decorator. `
+      + `Check that it is properly defined and set on the ${className(component)} class`
+    );
+  }
+}
+
+export class PropertyNotAnEventEmitterError extends CustomError {
+  constructor(key: string | symbol | number, component: any) {
+    super(
+      `${key} is not an instance of an EventEmitter. `
+      + `Check that it is properly defined and set on the ${className(component)} class`
+    );
+  }
+}
+
+export const outputProxy = <TComponent>(component: TComponent): PickByType<TComponent, EventEmitter<any>> => {
+  const directive = component
+    && 'constructor' in component
+    && directiveResolver.resolve((component as any).constructor);
+
+  const outputs = ((directive && directive.outputs) || [])
+    .map(output => output.split(':')[0]);
+
+  return new Proxy(
+    {},
+    {
+      get: (_, key: keyof TComponent) => {
+        if (!outputs.includes(key)) {
+          throw new PropertyNotMarkedAsOutputError(key, component);
+        }
+        if (!(component[key] instanceof EventEmitter)) {
+          throw new PropertyNotAnEventEmitterError(key, component);
+        }
+
+        return component[key];
+      }
+    }
+  ) as any;
+};

--- a/lib/tools/output-proxy.ts
+++ b/lib/tools/output-proxy.ts
@@ -18,7 +18,7 @@ export type PickByType<TObject, TPropertyType> = Pick<TObject, KeysOfType<TObjec
 export class PropertyNotMarkedAsOutputError extends CustomError {
   constructor(key: string | symbol | number, component: any) {
     super(
-      `${key} is not marked with the @Output() decorator. `
+      `${String(key)} is not marked with the @Output() decorator. `
       + `Check that it is properly defined and set on the ${className(component)} class`
     );
   }
@@ -27,7 +27,7 @@ export class PropertyNotMarkedAsOutputError extends CustomError {
 export class PropertyNotAnEventEmitterError extends CustomError {
   constructor(key: string | symbol | number, component: any) {
     super(
-      `${key} is not an instance of an EventEmitter. `
+      `${String(key)} is not an instance of an EventEmitter. `
       + `Check that it is properly defined and set on the ${className(component)} class`
     );
   }
@@ -45,7 +45,7 @@ export const outputProxy = <TComponent>(component: TComponent): PickByType<TComp
     {},
     {
       get: (_, key: keyof TComponent) => {
-        if (!outputs.includes(key)) {
+        if (!outputs.includes(String(key))) {
           throw new PropertyNotMarkedAsOutputError(key, component);
         }
         if (!(component[key] instanceof EventEmitter)) {


### PR DESCRIPTION
Now, instead of:

Shallow#render now returns an `outputs` object. The outputs object only allows referencing the EventEmitter properties of the test component that have been marked with `@Output`.

```typescript
it('emits "FOO" on button click', async () => {
  const {find, instance} = await shallow.render();
  find('button').triggerEventHandler('click', null);

  expect(instance.mySelectOutput.emit)
    .toHaveBeenCalledWith('FOO');
});
```

We can avoid the use of the component instance like this:
```typescript
it('emits "FOO" on button click', async () => {
  const {find, outputs} = await shallow.render();
  find('button').triggerEventHandler('click', null);

  expect(outputs.mySelectOutput.emit)
    .toHaveBeenCalledWith('FOO');
});
```

-- or, if you want to get weird with it --

```typescript
it('emits "FOO" on button click', async (done) => {
  const {find, outputs} = await shallow.render();
  outputs.mySelectOutput.subscribe(value => {
    expect(value).toBe('FOO');
    done();
  })
  find('button').triggerEventHandler('click', null);
});

