### PR TITLE
fix: Do not use moduleWithProviders in mock-module exports

### DIFF
--- a/lib/models/angular-module.ts
+++ b/lib/models/angular-module.ts
@@ -1,12 +1,3 @@
-import { Type } from '@angular/core';
+import { ModuleWithProviders, Type } from '@angular/core';
 
-// Angular 5x has ModuleWithProviders and Angular 6 uses a generic ModuleWithProviders<T>.
-// Building shallow with NG6 causes the d.ts output files to have a generic which is
-// incompatible with NG5's definition so I created this backward compatible type here.
-// Use this anywhere you would otherwise use a ModuleWithProvider
-export interface BackwardCompatibleModuleWithProviders {
-  ngModule: Type<any>;
-  providers?: any[];
-}
-
-export type AngularModule = Type<any> | BackwardCompatibleModuleWithProviders;
+export type AngularModule = Type<any> | ModuleWithProviders;

--- a/lib/tools/mock-module.ts
+++ b/lib/tools/mock-module.ts
@@ -14,6 +14,15 @@ export class InvalidModuleError {
   }
 }
 
+const collapseModuleWithProviders = <TThing>(mod: TThing): TThing => {
+  if (Array.isArray(mod)) {
+    return mod.map(collapseModuleWithProviders) as any;
+  } else if (isModuleWithProviders(mod)) {
+    return collapseModuleWithProviders(mod.ngModule) as any;
+  }
+  return mod;
+};
+
 export type AnyNgModule = any[] | AngularModule;
 export function mockModule<TModule extends AnyNgModule>(mod: TModule, setup: TestSetup<any>): TModule {
   const cached = setup.mockCache.find(mod);
@@ -44,7 +53,7 @@ export function mockModule<TModule extends AnyNgModule>(mod: TModule, setup: Tes
   const mockedModule: NgModule = {
     imports: ngMock(imports, setup),
     declarations: ngMock(declarations, setup),
-    exports: ngMock(exports, setup),
+    exports: collapseModuleWithProviders(ngMock(exports, setup)),
     entryComponents: ngMock(entryComponents, setup),
     providers: providers.map(p => mockProvider(p, setup)),
     schemas,

--- a/lib/tools/type-checkers.ts
+++ b/lib/tools/type-checkers.ts
@@ -1,10 +1,9 @@
-import { ClassProvider, ExistingProvider, FactoryProvider, PipeTransform, Provider, TypeProvider, ValueProvider } from '@angular/core';
-import { BackwardCompatibleModuleWithProviders } from '../models/angular-module';
+import { ClassProvider, ExistingProvider, FactoryProvider, ModuleWithProviders, PipeTransform, Provider, TypeProvider, ValueProvider } from '@angular/core';
 import { pipeResolver } from './reflect';
 
-export function isModuleWithProviders(provider: any): provider is BackwardCompatibleModuleWithProviders {
-  const key: keyof BackwardCompatibleModuleWithProviders = 'ngModule';
-  return typeof provider === 'object' && key in provider;
+export function isModuleWithProviders(thing: any): thing is ModuleWithProviders {
+  const key: keyof ModuleWithProviders = 'ngModule';
+  return typeof thing === 'object' && key in thing;
 }
 
 export function isValueProvider(provider: Provider): provider is ValueProvider {


### PR DESCRIPTION
Fix for #108 

Using `replaceModule` had a side-effect of potentially replacing an "exported" module with a `ModuleWithProviders` which is explicitly not supported in Angular modules. All Angular module exports *must* be classes with the `NgModule` decorator applied.

This
```typescript
Shallow.alwaysReplaceModule(RouterModule, RouterTestingModule.withRoutes(...));
```

Would cause an issue when a module under test was exporting the RouterModule like so:
```typescript
@NgModule({exports: [RouterModule]})
class MyModule {}
```

What happened was, `MyModule` was having it's export replaced with the `ModuleWithProviders` produced by the `RouterTestingModule` and TestBed would choke when parsing the test module.

The solution is to extract the `ngModule` out of the `moduleWithProviders` when it comes to module exports.