### PR TITLE
fix: Allow entry-components in TestModules

### DIFF
--- a/lib/examples/component-with-ng-component-outlet.spec.ts
+++ b/lib/examples/component-with-ng-component-outlet.spec.ts
@@ -1,0 +1,59 @@
+import { Component, Injectable, NgModule } from '@angular/core';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+@Component({
+  template: '<h1>Step</h1>',
+  selector: 'step'
+})
+class StepComponent {}
+
+@Injectable()
+class StepService {
+  getSteps() {
+    return [StepComponent];
+  }
+}
+
+@Component({
+  selector: 'step-display',
+  template: `
+    <div *ngFor="let step of stepService.getSteps()">
+      <ng-template *ngComponentOutlet="step"></ng-template>
+    </div>
+`,
+})
+class StepDisplayComponent {
+  constructor(public stepService: StepService) { }
+}
+
+@NgModule({
+  declarations: [StepDisplayComponent, StepComponent],
+  providers: [StepService],
+  entryComponents: [StepComponent]
+})
+class StepModule {}
+//////////////////////////
+
+describe('component with ngComponentOutlet and entry component', () => {
+  let shallow: Shallow<StepDisplayComponent>;
+  @Component({selector: 'dummy-step-one', template: '<i></i>'})
+  class DummyStepOne {}
+
+  @Component({selector: 'dummy-step-two', template: '<i></i>'})
+  class DummyStepTwo {}
+
+  beforeEach(() => {
+    shallow = new Shallow(StepDisplayComponent, StepModule)
+      .declare(DummyStepOne, DummyStepTwo)
+      .dontMock(DummyStepOne, DummyStepTwo)
+      .mock(StepService, {getSteps: () => [DummyStepOne, DummyStepTwo]});
+  });
+
+  it('renders dynamic steps', async () => {
+    const {find} = await shallow.render();
+
+    expect(find(DummyStepOne)).toHaveFoundOne();
+    expect(find(DummyStepTwo)).toHaveFoundOne();
+  });
+});

--- a/lib/models/renderer.spec.ts
+++ b/lib/models/renderer.spec.ts
@@ -231,4 +231,33 @@ describe('Renderer', () => {
       expect(instance instanceof NgIf).toBe(true);
     });
   });
+
+  describe('entry components', () => {
+    it('allows rendering entryComponents with some module magic', async () => {
+      @Component({
+        template: '<i class="my-entry">My Entry</i>'
+      })
+      class EntryComponent { }
+
+      @Component({
+        selector: 'my-normal-component',
+        template: '<i *ngComponentOutlet="entryComponentClass"></i>'
+      })
+      class NormalComponent {
+        entryComponentClass = EntryComponent;
+      }
+
+      @NgModule({
+        declarations: [NormalComponent, EntryComponent],
+        entryComponents: [EntryComponent]
+      })
+      class EntryTestModule {}
+
+      const mySetup = new TestSetup(NormalComponent, EntryTestModule);
+      mySetup.dontMock.push(NormalComponent, EntryComponent);
+      const {find} = await new Renderer(mySetup).render({whenStable: true});
+
+      expect(find('.my-entry')).toHaveFoundOne();
+    });
+  });
 });

--- a/lib/models/test-setup.ts
+++ b/lib/models/test-setup.ts
@@ -10,6 +10,7 @@ export class TestSetup<TComponent> {
   readonly mockPipes = new Map<PipeTransform | Type<PipeTransform>, Function>(); /* tslint:disable-line ban-types */
   readonly mockCache = new MockCache();
   readonly providers: Provider[] = [];
+  readonly declarations: Type<any>[] = [];
   readonly imports: AngularModule[] = [];
 
   constructor(

--- a/lib/shallow.spec.ts
+++ b/lib/shallow.spec.ts
@@ -15,7 +15,7 @@ class TestService {
 
 @Pipe({name: 'test'})
 class TestPipe implements PipeTransform {
-  transform(key: string) {
+  transform() {
     return {test: 'pipe'};
   }
 }
@@ -142,6 +142,16 @@ describe('Shallow', () => {
         .provide(MyService);
 
       expect(shallow.setup.providers).toContain(MyService);
+    });
+  });
+
+  describe('declare', () => {
+    it('adds to the setup.declarations array', () => {
+      class MyComponent {}
+      const shallow = new Shallow(TestComponent, TestModule)
+        .declare(MyComponent);
+
+      expect(shallow.setup.declarations).toContain(MyComponent);
     });
   });
 

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -58,6 +58,11 @@ export class Shallow<TTestComponent> {
     Shallow._alwaysReplaceModule.forEach((value, key) => this.setup.moduleReplacements.set(key, value));
   }
 
+  declare(...declarations: Type<any>[]): this {
+    this.setup.declarations.push(...declarations);
+    return this;
+  }
+
   provide(...providers: Provider[]): this {
     this.setup.providers.push(...providers);
     return this;


### PR DESCRIPTION
Should fix issue #117. Turns out that using EntryComponents in TestBed is [pretty tough](https://github.com/angular/angular/issues/12079) but we are able to swallow all that complexity in shallow-render so there's no special handling on the user's end!

Thanks @nbcormier for reporting!

Quick notes:
When rendering "normal" components, Angular looks for "selectors" in the template and searches in the module-tree for a component that matches the selector. In testing, we have total control over the module so we can swap out dummy components to match up with selectors and our tests are happy.

EntryComponents bypass this and are referenced directly by their class object instead of being plucked out of the module by their selectors. This can make components that render EntryComponents hard to test. 

Here's what I mean:
```typescript
@Injectable()
class ComponentService {
   getDynamicComponent() {
     return Math.random() === 1
       ? FooComponent
       : BarComponent;
   }
}
```

```typescript
@Component({
  selector: 'foo',
  template: '<ng-container *ngComponentOutlet="componentService.getDynamicComponent()" />'
})
class MyComponent {
  constructor(public componentService: ComponentService) {}
}
```

If we want to test `MyComponent`, we have two options:
1. Use the *real* `ComponentService` and render the *real* `FooComponent` or `BarComponent`. This is typically undesirable because Foo or Bar components could be complex which would require the tests for `MyComponent` to provide setup/mocks/etc to satisfy Foo and Bar components requirements.
2. Mock the `ComponentService` and provide *dummy* entry components. 😎 


Here's an example of option 2:
```typescript
describe('option 2', () => {
  let shallow: Shallow<MyComponent>;
  @Component({selector: 'dummy', template: '<i></i>'})
  class DummyComponent {}

  beforeEach(() => {
    shallow = new Shallow(MyComponent, MyModule)
      .declare(DummyComponent) // <-- New feature!
      // We cannot mock the DummyComponent because the getDynamicComponent method below
      // will return the *REAL* component so the *actual* DummyComponent must exist in our test setup!
      .dontMock(DummyComponent)
      .mock(ComponentService, {getDynamicComponent: () => DummyComponent});
  });

  it('renders the component from the ComponentSevice', async () => {
    const {find} = await shallow.render();

    expect(find(DummyComponent)).toHaveFoundOne();
  });
});
```

This means that if we want to test an EntryComponent that is provided by an external service, we will be required to mock the service that provides the component **and** we will have to declare a suitable dummy component to render.

To make this easier, I've added a `declare` feature:
`Shallow#declare(...declarations: Type<any>[])`

This will add custom declarations to your test module and automatically make them entry components.

I originally avoided this feature because it seems easy to abuse but it seems there are pretty good reasons to have the feature.
