### PR TITLE
feat: Add provideMock

### DIFF
--- a/lib/shallow.spec.ts
+++ b/lib/shallow.spec.ts
@@ -145,6 +145,17 @@ describe('Shallow', () => {
     });
   });
 
+  describe('provideMock', () => {
+    it('adds to the setup.providers and setup.dontMock', () => {
+      class MyService {}
+      const shallow = new Shallow(TestComponent, TestModule)
+          .provideMock(MyService);
+
+      expect(shallow.setup.providers).toContain(MyService);
+      expect(shallow.setup.dontMock).toContain(MyService);
+    });
+  });
+
   describe('declare', () => {
     it('adds to the setup.declarations array', () => {
       class MyComponent {}

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -68,6 +68,12 @@ export class Shallow<TTestComponent> {
     return this;
   }
 
+  provideMock(...providers: Provider[]): this {
+    this.setup.providers.push(...providers);
+    this.setup.dontMock.push(...providers);
+    return this;
+  }
+
   dontMock(...things: any[]): this {
     this.setup.dontMock.push(...things);
     return this;


### PR DESCRIPTION
provideMock combines provide() and neverMock() for allowing the
developer to provide his/her own mock instead of relying on
shallow-render.