### PR TITLE
fix(#131): Fix Jest Matchers namespace

### DIFF
--- a/lib/test-frameworks/namespaces.ts
+++ b/lib/test-frameworks/namespaces.ts
@@ -6,6 +6,6 @@ declare global {
     export interface ArrayLikeMatchers<T> extends BaseArrayLikeMatchers<T> {}
   }
   namespace jest {
-    export interface ArrayLikeMatchers<T> extends BaseArrayLikeMatchers<T> {}
+    export interface Matchers<R> extends BaseArrayLikeMatchers<R> {}
   }
 }


### PR DESCRIPTION
Fixes #131
Add custom matchers to the jest interface `Matchers<R>`, which is the return type of `expect()`