### PR TITLE
fix: Use TestBed.overrideProvider to support rootProviders

### DIFF
--- a/lib/examples/component-with-provided-in-root.spec.ts
+++ b/lib/examples/component-with-provided-in-root.spec.ts
@@ -1,0 +1,39 @@
+import { Component, Injectable, NgModule } from '@angular/core';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+@Injectable({providedIn: 'root'})
+class RootService {
+  getRootName() {
+    return 'MY-ROOT-NAME';
+  }
+}
+
+@Component({
+  selector: 'root-label',
+  template: '<label>{{rootService.getRootName()}}</label>',
+})
+class RootLabelComponent {
+  constructor(public rootService: RootService) {}
+}
+
+@NgModule({
+  declarations: [RootLabelComponent],
+})
+class RootLabelModule {}
+//////////////////////////
+
+describe('component with service providedIn root', () => {
+  let shallow: Shallow<RootLabelComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(RootLabelComponent, RootLabelModule)
+      .mock(RootService, {getRootName: () => 'MOCKED ROOT NAME'});
+  });
+
+  it('Uses the rootName from the RootService', async () => {
+    const {element} = await shallow.render();
+
+    expect(element.nativeElement.innerText).toBe('MOCKED ROOT NAME');
+  });
+});

--- a/lib/models/mock-of-provider.ts
+++ b/lib/models/mock-of-provider.ts
@@ -1,8 +1,9 @@
-import { Provider } from '@angular/core';
+import { Type } from '@angular/core';
 import { testFramework } from '../test-framework';
+import { getProviderName } from '../tools/get-provider-name';
 
 export class MockOfProvider {
-  constructor(public mockOf: Provider, stubs: any = {}) {
+  constructor(public mockOf: Type<any>, stubs: any = {}) {
     Object.assign(this, stubs);
     Object.keys(stubs).forEach(key => {
       if (typeof (this as any)[key] === 'function' && !testFramework.isSpy((this as any)[key])) {
@@ -11,3 +12,13 @@ export class MockOfProvider {
     });
   }
 }
+
+export const mockProviderClass = <TProvider extends Type<any>>(provider: TProvider, stubs: any): TProvider => {
+  class MockProvider extends MockOfProvider { /* tslint:disable-line no-unnecessary-class */
+    constructor() {
+      super(provider, stubs);
+    }
+  }
+  Object.defineProperty(MockProvider, 'name', {value: `MockOf${getProviderName(provider)}`});
+  return MockProvider as TProvider;
+};

--- a/lib/models/renderer.ts
+++ b/lib/models/renderer.ts
@@ -7,6 +7,7 @@ import { createTestModule } from '../tools/create-test-module';
 import { mockProvider } from '../tools/mock-provider';
 import { directiveResolver } from '../tools/reflect';
 import { CustomError } from './custom-error';
+import { mockProviderClass } from './mock-of-provider';
 import { RecursivePartial } from './recursive-partial';
 import { Rendering, RenderOptions } from './rendering';
 import { TestSetup } from './test-setup';
@@ -121,6 +122,14 @@ export class Renderer<TComponent> {
         }
       });
     }
+
+    // This takes care of providedIn 'root'
+    this._setup.mocks.forEach((mock, thingToMock) => {
+      if (!directiveResolver.isDirective(thingToMock)) {
+        const MockProvider = mockProviderClass(thingToMock, mock);
+        TestBed.overrideProvider(thingToMock, {useValue: new MockProvider()});
+      }
+    });
 
     await TestBed.configureTestingModule({
       imports: [createTestModule(this._setup, [this._setup.testComponent, ComponentClass])],

--- a/lib/tools/mock-provider.ts
+++ b/lib/tools/mock-provider.ts
@@ -1,7 +1,6 @@
 import { APP_INITIALIZER, Provider, TypeProvider, ValueProvider } from '@angular/core';
-import { MockOfProvider } from '../models/mock-of-provider';
+import { mockProviderClass } from '../models/mock-of-provider';
 import { TestSetup } from '../models/test-setup';
-import { getProviderName } from './get-provider-name';
 import { isClassProvider, isExistingProvider, isFactoryProvider, isTypeProvider } from './type-checkers';
 
 const recursiveIncludes = (array: any[], item: any): boolean =>
@@ -30,12 +29,7 @@ export function mockProvider(provider: Provider, setup: TestSetup<any>): Provide
     return provider;
   }
 
-  class MockProvider extends MockOfProvider { /* tslint:disable-line no-unnecessary-class */
-    constructor() {
-      super(provider, userMocks);
-    }
-  }
-  Object.defineProperty(MockProvider, 'name', {value: `MockOf${getProviderName(provider)}`});
+  const MockProvider = mockProviderClass(provide, userMocks);
 
   const prov = {
     provide,

--- a/lib/tools/ng-mock.ts
+++ b/lib/tools/ng-mock.ts
@@ -64,7 +64,8 @@ export function ngMock<TThing extends NgMockable | NgMockable[]>(thing: TThing, 
       throw new Error(`Shallow doesn't know how to mock: ${thing}`);
     }
   } catch (e) {
-    throw new Error(`Shallow ran into some trouble mocking ${(thing as any).name || thing}. Try skipping it with dontMock or neverMock.\n------------- MOCK ERROR -------------\n${e && e.stack || e}\n----------- END MOCK ERROR -----------`);
+    const name = (thing && (thing as any).name) || thing;
+    throw new Error(`Shallow ran into some trouble mocking ${name}. Try skipping it with dontMock or neverMock.\n------------- MOCK ERROR -------------\n${e && e.stack || e}\n----------- END MOCK ERROR -----------`);
   }
   return setup.mockCache.add(thing, mock) as TThing;
 }


### PR DESCRIPTION
fix #128

Taking @apastuhov's suggestion and simply using `TestBed.overrideProvider`. Sorry it took so long to realize this was, indeed, the simplest way forward.

Unfortunately, this approach will *not* auto-mock root providers, they must specify some sort of mock with `shallow.mock` for them to take effect.