### PR TITLE
feat: Do not mock certain core Angular things by default

### DIFF
--- a/lib/examples/component-with-forms.spec.ts
+++ b/lib/examples/component-with-forms.spec.ts
@@ -1,0 +1,50 @@
+
+import { Component, NgModule } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Shallow } from '../shallow';
+
+@Component({
+  selector: 'foo',
+  template: `
+    <input id="name" type="text" [(ngModel)]="name"/>
+    <input id="nickname" type="text" [formControl]="nicknameControl"/>
+  `
+})
+class FooComponent {
+  name = 'Brandon';
+  nicknameControl = new FormControl('B-ran');
+}
+
+@NgModule({
+  declarations: [FooComponent],
+  imports: [FormsModule, ReactiveFormsModule]
+})
+class FooModule {}
+
+describe('component with forms', () => {
+  let shallow: Shallow<FooComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(FooComponent, FooModule);
+  });
+
+  it('updates the name property when the input changes', async () => {
+    const {find, instance, fixture} = await shallow
+      .render();
+    find('#name').nativeElement.value = 'foo';
+    find('#name').nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(instance.name).toBe('foo');
+  });
+
+  it('updates the nickname property when the input changes', async () => {
+    const {find, instance, fixture} = await shallow
+      .render();
+    find('#nickname').nativeElement.value = 'foo';
+    find('#nickname').nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(instance.nicknameControl.value).toBe('foo');
+  });
+});

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -1,18 +1,26 @@
 import { CommonModule } from '@angular/common';
 import { InjectionToken, ModuleWithProviders, PipeTransform, Provider, Type } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserModule, HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
 import { RecursivePartial } from './models/recursive-partial';
 import { InvalidStaticPropertyMockError, Renderer } from './models/renderer';
 import { Rendering, RenderOptions } from './models/rendering';
 import { TestSetup } from './models/test-setup';
 import './test-framework';
 
+const NEVER_MOCKED_ANGULAR_STUFF = [
+  CommonModule,
+  BrowserModule,
+  FormsModule,
+  ReactiveFormsModule,
+  HAMMER_GESTURE_CONFIG
+];
 export class Shallow<TTestComponent> {
   readonly setup: TestSetup<TTestComponent>;
 
   // Never mock the Angular Common Module, it includes things like *ngIf and basic
   // template directives.
-  private static readonly _neverMock: any[] = [CommonModule, BrowserModule];
+  private static readonly _neverMock: any[] = [...NEVER_MOCKED_ANGULAR_STUFF];
   static neverMock(...things: any[]) {
     this._neverMock.push(...things);
     return Shallow;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@angular/common": ">=6.x <=8.x",
     "@angular/compiler": ">=6.x <=8.x",
     "@angular/core": ">=6.x <=8.x",
+    "@angular/forms": ">=6.x <=8.x",
     "@angular/platform-browser": ">=6.x <=8.x"
   },
   "dependencies": {


### PR DESCRIPTION
Trying to use mocks of the FormsModule or ReactiveForms module is pretty-much pointless. The only solution to this is to *manually* add `Shallow.neverMock(FormsModule, ReactiveFormsModule)` into your test setup. I believe everyone who uses forms must do this so I just do it by default now in shallow.

Same for `HAMMER_GESTURE_CONFIG`.