### PR TITLE
feat: Allow rendering of structural directives

### DIFF
--- a/lib/examples/component-with-structural-directive.spec.ts
+++ b/lib/examples/component-with-structural-directive.spec.ts
@@ -1,0 +1,61 @@
+import { Component, Directive, Input, NgModule } from '@angular/core';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+@Component({
+  selector: 'heading',
+  template: `
+    <h1 *myStructuralDirective="'first'">Hi there!</h1>
+    <h1 *myStructuralDirective="'second'">Hi there!</h1>
+  `,
+})
+class HeadingComponent {}
+
+@Directive({
+  selector: '[myStructuralDirective]',
+})
+class MyStructuralDirective {
+  @Input() myStructuralDirective: string;
+}
+
+@NgModule({
+  declarations: [HeadingComponent, MyStructuralDirective]
+})
+class HeadingModule {}
+//////////////////////////
+
+describe('component with structural directive', () => {
+  let shallow: Shallow<HeadingComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(HeadingComponent, HeadingModule);
+  });
+
+  it('renders both headings', async () => {
+    const {find} = await shallow
+      .withStructuralDirective(MyStructuralDirective)
+      .render();
+
+    expect(find('h1')).toHaveFound(2);
+  });
+
+  it('renders the second heading', async () => {
+    const {find, findStructuralDirective, renderStructuralDirective} = await shallow.render();
+    const found = findStructuralDirective(
+      MyStructuralDirective,
+      {query: d => d.myStructuralDirective === 'first'}
+    );
+    renderStructuralDirective(found);
+
+    expect(find('h1')).toHaveFoundOne();
+  });
+
+  it('unrenders the heading', async () => {
+    const {find, renderStructuralDirective} = await shallow
+      .withStructuralDirective(MyStructuralDirective)
+      .render();
+    renderStructuralDirective(MyStructuralDirective, false);
+
+    expect(find('h1')).toHaveFound(0);
+  });
+});

--- a/lib/models/rendering.ts
+++ b/lib/models/rendering.ts
@@ -1,6 +1,7 @@
 import { DebugElement, EventEmitter, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { MockedDirective } from 'ng-mocks';
 import { outputProxy, PickByType } from '../tools/output-proxy';
 import { createQueryMatch, QueryMatch } from './query-match';
 import { TestSetup } from './test-setup';
@@ -24,32 +25,78 @@ export class Rendering<TComponent, TBindings> {
   // The following methods MUST be arrow functions so they can be deconstructured
   // off of the class
   /////////////////////////////////////////////////////////////////////////////
-  // TODO: Allow a second argument specifying the context of the search so we
-  // don't always have to search from the top fixture.
-  readonly find = (cssOrDirective: string | Type<any>) => {
+  public find = (cssOrDirective: string | Type<any>, options?: {query?: string}): QueryMatch<DebugElement> => {
     const query = typeof cssOrDirective === 'string'
       ? By.css(cssOrDirective)
       : By.directive(this._setup.mockCache.find(cssOrDirective) || cssOrDirective);
-    const matches = this.fixture.debugElement.queryAll(query);
+    const mainQuery = this.fixture.debugElement.queryAll(query);
+    const found = options && options.query
+      ? this.fixture.debugElement.queryAll(By.css(options.query)).filter(item => mainQuery.includes(item))
+      : mainQuery;
 
-    if (matches.length && matches[0] === this.element) {
-      throw new Error(`Don't use 'find' to search for your test component, it is automatically returned by the shallow renderer`);
+    if (found.includes(this.element)) {
+      throw new Error(`Don't search for your test component, it is automatically returned by the shallow renderer`);
     }
 
-    return createQueryMatch(matches);
+    return createQueryMatch(found);
   }
 
-  readonly findComponent = <TMatch>(component: Type<TMatch>): QueryMatch<TMatch> =>
-    createQueryMatch(this.find(component).map(i => i.componentInstance as TMatch))
+  readonly findComponent = <TMatch>(component: Type<TMatch>, options?: {query?: string}): QueryMatch<TMatch> =>
+    this.findDirective(component, options)
 
-  readonly findDirective = <TDirective>(directive: Type<TDirective>): QueryMatch<TDirective> => {
-    const found = this.find(directive);
+  readonly findDirective = <TDirective>(directive: Type<TDirective>, options?: {query?: string}): QueryMatch<TDirective> => {
     const directiveOrMock = this._setup.mockCache.find(directive) || directive;
-
-    return createQueryMatch(found.map(i => i.injector.get<TDirective>(directiveOrMock)));
+    const foundElements = options && options.query
+      ? this.fixture.debugElement.queryAll(By.css(options.query))
+      : this.find(directive, options);
+    const foundDirectives = foundElements
+      .map(result => {
+        try { return result.injector.get<TDirective>(directiveOrMock); } catch (e) { return undefined; }
+      })
+      .filter(i => i) as TDirective[];
+    if (foundDirectives.some(i => i as any === this.instance)) {
+      throw new Error(`Don't search for your test component, it is automatically returned by the shallow renderer`);
+    }
+    return createQueryMatch(foundDirectives);
   }
 
   readonly get = <TClass>(queryClass: Type<TClass>): TClass => TestBed.get(queryClass);
 
   readonly outputs: PickByType<TComponent, EventEmitter<any>> = outputProxy(this.instance);
+
+  readonly findStructuralDirective = <TDirective>(directiveClass: Type<TDirective>, options?: {query?(d: TDirective): boolean}) =>
+    createQueryMatch(
+      this.fixture.debugElement.queryAllNodes(node => {
+        try {
+          const instance = node.injector.get(directiveClass);
+          if (instance) {
+            return options && options.query ? options.query(instance) : true;
+          }
+        } catch (e) { } // tslint:disable-line no-empty
+        return false;
+      })
+      .map(node => node.injector.get<TDirective>(directiveClass))
+    )
+
+  readonly renderStructuralDirective = (directiveClassOrObject: Type<any> | QueryMatch<any> | object, renderContents = true) => {
+    const directives: Array<MockedDirective<{}>> = typeof directiveClassOrObject === 'function'
+      ? this.findStructuralDirective<MockedDirective<{}>>(directiveClassOrObject)
+      : directiveClassOrObject.length ? directiveClassOrObject : [directiveClassOrObject];
+
+    if (!directives.length) {
+      throw new Error(`Tried to render a structural directive but none were found.`);
+    }
+
+    directives.forEach(foundDirective => {
+      if (!foundDirective.__viewContainer) {
+        const directiveName = Object.getPrototypeOf(foundDirective).constructor.name;
+        throw new Error(`You may only manually render mocked directives with "renderStructuralDirective". Tried to render a structural directive (${directiveName}) but the directive is not mocked.`);
+      }
+      if (renderContents) {
+        foundDirective.__render();
+      } else {
+        foundDirective.__viewContainer.clear();
+      }
+    });
+  }
 }

--- a/lib/models/test-setup.ts
+++ b/lib/models/test-setup.ts
@@ -12,6 +12,8 @@ export class TestSetup<TComponent> {
   readonly providers: Provider[] = [];
   readonly declarations: Type<any>[] = [];
   readonly imports: AngularModule[] = [];
+  readonly withStructuralDirectives = new Map<Type<any>, boolean>();
+  public alwaysRenderStructuralDirectives = false;
 
   constructor(
     public readonly testComponent: Type<TComponent>,

--- a/lib/shallow.spec.ts
+++ b/lib/shallow.spec.ts
@@ -126,6 +126,21 @@ describe('Shallow', () => {
     });
   });
 
+  describe('alwaysWithStructuralDirective', () => {
+    it('adds the directive to the test setup', () => {
+      class DummyDirective {}
+      class DummyFalseDirective {}
+      Shallow.alwaysWithStructuralDirective(DummyDirective, true);
+      Shallow.alwaysWithStructuralDirective(DummyFalseDirective, false);
+      const shallow = new Shallow(TestComponent, TestModule);
+
+      expect(shallow.setup.withStructuralDirectives.get(DummyDirective))
+        .toBe(true);
+      expect(shallow.setup.withStructuralDirectives.get(DummyFalseDirective))
+        .toBe(false);
+    });
+  });
+
   describe('dontMock', () => {
     it('adds things to setup.dontMock', () => {
       const shallow = new Shallow(TestComponent, TestModule)
@@ -258,6 +273,21 @@ describe('Shallow', () => {
 
       expect(shallow.setup.moduleReplacements.get(TestModule))
         .toBe(ReplacementModule);
+    });
+  });
+
+  describe('withStructuralDirective', () => {
+    it('adds the directive to the test setup', () => {
+      class DummyDirective {}
+      class DummyFalseDirective {}
+      const shallow = new Shallow(TestComponent, TestModule)
+        .withStructuralDirective(DummyDirective, true)
+        .withStructuralDirective(DummyFalseDirective, false);
+
+      expect(shallow.setup.withStructuralDirectives.get(DummyDirective))
+        .toBe(true);
+      expect(shallow.setup.withStructuralDirectives.get(DummyFalseDirective))
+        .toBe(false);
     });
   });
 

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -57,13 +57,32 @@ export class Shallow<TTestComponent> {
     return Shallow;
   }
 
+  private static _alwaysRenderStructuralDirectives = false;
+  public static alwaysRenderStructuralDirectives() {
+    this._alwaysRenderStructuralDirectives = true;
+    return Shallow;
+  }
+
+  private static readonly _alwaysWithStructuralDirectives = new Map<Type<any>, boolean>();
+  public static alwaysWithStructuralDirective(directive: Type<any>, renderContents: boolean = true) {
+    this._alwaysWithStructuralDirectives.set(directive, renderContents);
+    return Shallow;
+  }
+
   constructor(testComponent: Type<TTestComponent>, testModule: Type<any> | ModuleWithProviders) {
     this.setup = new TestSetup(testComponent, testModule);
     this.setup.dontMock.push(testComponent, ...Shallow._neverMock);
     this.setup.providers.push(...Shallow._alwaysProvide);
     this.setup.imports.push(...Shallow._alwaysImport);
+    this.setup.alwaysRenderStructuralDirectives = Shallow._alwaysRenderStructuralDirectives;
     Shallow._alwaysMock.forEach((value, key) => this.setup.mocks.set(key, value));
     Shallow._alwaysReplaceModule.forEach((value, key) => this.setup.moduleReplacements.set(key, value));
+    Shallow._alwaysWithStructuralDirectives.forEach((value, key) => this.setup.withStructuralDirectives.set(key, value));
+  }
+
+  withStructuralDirective(directive: Type<any>, renderContents = true) {
+    this.setup.withStructuralDirectives.set(directive, renderContents);
+    return this;
   }
 
   declare(...declarations: Type<any>[]): this {
@@ -143,4 +162,5 @@ export class Shallow<TTestComponent> {
       return renderer.render();
     }
   }
+
 }

--- a/lib/tools/ng-mock.spec.ts
+++ b/lib/tools/ng-mock.spec.ts
@@ -176,4 +176,36 @@ describe('ng-mock', () => {
 
     expect(mocked).toBe(moduleWithProviders);
   });
+
+  it('renders on ngOnInit for all directives when alwaysRenderStructuralDirectives is true', () => {
+    testSetup.alwaysRenderStructuralDirectives = true;
+    const mocked = ngMock(FooDirective, testSetup);
+    const instance = new mocked() as ngMocksLib.MockedDirective<{}>;
+    spyOn(instance, '__render');
+    (instance as any).ngOnInit();
+
+    expect(instance.__render).toHaveBeenCalled();
+  });
+
+  it('renders on ngOnInit for directives specified in withStructuralDirective', () => {
+    testSetup.alwaysRenderStructuralDirectives = false;
+    testSetup.withStructuralDirectives.set(FooDirective, true);
+    const mocked = ngMock(FooDirective, testSetup);
+    const instance = new mocked() as ngMocksLib.MockedDirective<{}>;
+    spyOn(instance, '__render');
+    (instance as any).ngOnInit();
+
+    expect(instance.__render).toHaveBeenCalled();
+  });
+
+  it('does not render on ngOnInit for directives not specified in withStructuralDirective', () => {
+    testSetup.alwaysRenderStructuralDirectives = false;
+    testSetup.withStructuralDirectives.set(FooDirective, false);
+    const mocked = ngMock(FooDirective, testSetup);
+    const instance = new mocked() as ngMocksLib.MockedDirective<{}>;
+    spyOn(instance, '__render');
+    (instance as any).ngOnInit();
+
+    expect(instance.__render).not.toHaveBeenCalled();
+  });
 });

--- a/lib/tools/ng-mock.ts
+++ b/lib/tools/ng-mock.ts
@@ -41,6 +41,16 @@ export function ngMock<TThing extends NgMockable | NgMockable[]>(thing: TThing, 
       mock = MockPipe(thing as Type<any>, setup.mockPipes.get(thing));
     } else if (typeof thing === 'function') { // tslint:disable-line strict-type-predicates
       mock = MockDeclaration(thing as Type<any>);
+      if (
+        setup.withStructuralDirectives.get(thing as Type<any>)
+        || (setup.alwaysRenderStructuralDirectives && setup.withStructuralDirectives.get(thing as Type<any>) !== false)
+      ) {
+        mock.prototype.ngOnInit = () => undefined;
+        testFramework.spyOn(mock.prototype, 'ngOnInit', function() {
+          // tslint:disable-next-line: no-empty
+          try { this.__render(); } catch (e) { }
+        });
+      }
       fixEmptySelector(thing as Type<any>, mock);
       const stubs = setup.mocks.get(thing);
       if (stubs) {


### PR DESCRIPTION
New features:
### The ability to search for components/directives by Class *and* css styles

```typescript
const greenFoo = findComponent(FooComponent, {query: '.green'})
```

### The ability to search for structural directives

```typescript
const {findStructuralDirective} = await shallow.render();
const fooDirective = findStructuralDirective(FooDirective);
```
-- or -- with a predicate
```typescript
const {findStructuralDirective} = await shallow.render();
const fooDirective = findStructuralDirective(FooDirective, fd => fd.directiveProperty === 'cool');
```


### Targeted rendering of structural directives
```typescript
const {renderStructuralDirective} = await shallow.render();
renderStructuralDirective(FooDirective);
// Un-render with a second argument
renderStructuralDirective(FooDirective, false);
```
-- or -- render specific instances of a directive
```typescript
const {findStructuralDirective, renderStructuralDirective} = await shallow.render();
const coolFooDirective = findStructuralDirective(FooDirective, fd => fd.directiveProperty === 'cool');
renderStructuralDirective(coolFooDirective);
```

### Render-time control of structural directives
```typescript
const shallow = new Shallow(TestComponent, TestModule)
  .withStructuralDirective(MyDirective)
  .withStructuralDirective(MyOtherDirective, false);
```

### Global control of structural directives
```typescript
Shallow
  .alwaysWithStructuralDirective(MyDirective)
  .alwaysWithStructuralDirective(MyOtherDirective, false);
```