### PR TITLE
docs: Additional examples for events

### DIFF
--- a/lib/examples/component-with-input.spec.ts
+++ b/lib/examples/component-with-input.spec.ts
@@ -1,0 +1,49 @@
+import { Component, NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+
+@Component({
+  selector: 'custom-form',
+  template: `
+      <input id="customInput" [(ngModel)]="text">
+  `,
+})
+class CustomFormComponent {
+  text = 'I am complete';
+}
+
+@NgModule({
+  imports: [FormsModule],
+  declarations: [CustomFormComponent]
+})
+class CustomInputModule {}
+//////////////////////////
+
+describe('component with input', () => {
+  let shallow: Shallow<CustomFormComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(CustomFormComponent, CustomInputModule);
+  });
+
+  it('displays an input with default value', async () => {
+    const {find} = await shallow.render();
+
+    expect(find('#customInput').nativeElement.value)
+      .toBe('I am complete');
+  });
+
+  it('input updates ngModel', async () => {
+    const {find, instance} = await shallow.render();
+
+    const input = find('#customInput');
+    input.nativeElement.value = 'It works!';
+    input.triggerEventHandler('input', {target: input.nativeElement});
+
+    expect(instance.text)
+      .toBe('It works!');
+  });
+
+});

--- a/lib/examples/component-with-output.spec.ts
+++ b/lib/examples/component-with-output.spec.ts
@@ -1,0 +1,61 @@
+import { Component, EventEmitter, NgModule, Output } from '@angular/core';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+
+interface MyEvent {
+  id: number;
+  name: string;
+}
+
+@Component({
+  selector: 'inner-component',
+  template: `
+    <p>Hello</p>
+  `,
+})
+class InnerComponent {
+  @Output() output = new EventEmitter<MyEvent>();
+}
+@Component({
+  selector: 'outer-component',
+  template: `
+    <inner-component (output)="outputHandler($event)"></inner-component>
+  `,
+})
+class OuterComponent {
+  outputHandler(event: MyEvent) {
+  // implementation
+  }
+}
+
+@NgModule({
+  declarations: [InnerComponent, OuterComponent]
+})
+class CustomInputModule {}
+//////////////////////////
+
+describe('component with output', () => {
+  let shallow: Shallow<OuterComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(OuterComponent, CustomInputModule);
+  });
+
+  it('displays an inner component', async () => {
+    const {find} = await shallow.render();
+
+    expect(find('inner-component')).toHaveFound(1);
+  });
+
+  it('input updates ngModel', async () => {
+    const {find, instance} = await shallow.render();
+    spyOn(instance, 'outputHandler');
+
+    const innerComponent = find('inner-component');
+    innerComponent.triggerEventHandler('output', {id: 1, name: 'myEvent'} as MyEvent);
+
+    expect(instance.outputHandler).toHaveBeenCalledWith({id: 1, name: 'myEvent'});
+  });
+
+});

--- a/lib/examples/component-with-reactive-input.spec.ts
+++ b/lib/examples/component-with-reactive-input.spec.ts
@@ -1,0 +1,75 @@
+import { Component, NgModule, OnDestroy, OnInit } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { Shallow } from '../shallow';
+
+////// Module Setup //////
+
+@Component({
+  selector: 'custom-form',
+  template: `
+      <input id="customInput" [formControl]="myControl">
+  `,
+})
+class CustomFormComponent implements OnInit, OnDestroy {
+  myControl = new FormControl('I am complete');
+  subscription = new Subscription();
+
+  ngOnInit() {
+    this.subscription.add(
+        this.myControl.valueChanges.subscribe(change => this.inputHandler(change))
+    );
+  }
+
+  inputHandler(text: string) {
+  //  implementation
+    return 2 + 2;
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+}
+
+@NgModule({
+  imports: [ReactiveFormsModule],
+  declarations: [CustomFormComponent]
+})
+class CustomInputModule {}
+//////////////////////////
+
+describe('component with reactive input', () => {
+  let shallow: Shallow<CustomFormComponent>;
+
+  beforeEach(() => {
+    shallow = new Shallow(CustomFormComponent, CustomInputModule);
+  });
+
+  it('displays an input with default value', async () => {
+    const {find} = await shallow.render();
+
+    expect(find('#customInput').nativeElement.value)
+      .toBe('I am complete');
+  });
+
+  it('destroy cancel subscriptions', async () => {
+    const {instance} = await shallow.render();
+    spyOn(instance.subscription, 'unsubscribe');
+
+    instance.ngOnDestroy();
+
+    expect(instance.subscription.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('input change calls inputHandler', async () => {
+    const {find, instance} = await shallow.dontMock(ReactiveFormsModule).render();
+    spyOn(instance, 'inputHandler');
+
+    const input = find('#customInput');
+    input.nativeElement.value = 'It works!';
+    input.triggerEventHandler('input', {target: input.nativeElement});
+
+    expect(instance.inputHandler).toHaveBeenCalledWith('It works!');
+  });
+
+});

--- a/lib/examples/component-with-reactive-input.spec.ts
+++ b/lib/examples/component-with-reactive-input.spec.ts
@@ -1,6 +1,6 @@
 import { Component, NgModule, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { Subscription } from 'rxjs';
+import { Subscription } from 'rxjs'; // tslint:disable-line no-implicit-dependencies
 import { Shallow } from '../shallow';
 
 ////// Module Setup //////


### PR DESCRIPTION
Hi!

I really liked your project but I found out that simulating some integrations were difficult for me and looking for solution wasn't easy => input html element and @Outputs. I created a couple of examples that illustrate how can you use shallow-render to also test such cases. Hopes that they will be useful!

If you have any ideas about changing code style in proposed examples please let me know.

Cheers,
Mati 