### PR TITLE
feat: Allow directly mocking injection tokens

### DIFF
--- a/lib/examples/mocking-injection-tokens.spec.ts
+++ b/lib/examples/mocking-injection-tokens.spec.ts
@@ -6,22 +6,34 @@ interface CustomStyles {
   defaultLabelClass: string;
 }
 const STYLE_TOKEN = new InjectionToken<CustomStyles>('My custom styles');
+const STRING_TOKEN = new InjectionToken<string>('My string token');
+const FUNCTION_TOKEN = new InjectionToken<() => string>('My function token');
 
 @Component({
   selector: 'label-text',
   template: `
-    <label [class]="styles.defaultLabelClass">
+    <span id="token-string">{{ stringToken }}</span>
+    <span id="token-function">{{ functionToken() }}</span>
+    <label [class]="stylesToken.defaultLabelClass">
       <ng-content></ng-content>
     </label>
   `
 })
 class LabelTextComponent {
-  constructor(@Inject(STYLE_TOKEN) public styles: CustomStyles) {}
+  constructor(
+    @Inject(STYLE_TOKEN) public stylesToken: CustomStyles,
+    @Inject(STRING_TOKEN) public stringToken: string,
+    @Inject(FUNCTION_TOKEN) public functionToken: () => string
+  ) {}
 }
 
 @NgModule({
   declarations: [LabelTextComponent],
-  providers: [{ provide: STYLE_TOKEN, useValue: { defaultLabelClass: 'uppercase font-size-small' } }]
+  providers: [
+    { provide: STYLE_TOKEN, useValue: { defaultLabelClass: 'uppercase font-size-small' } },
+    { provide: STRING_TOKEN, useValue: 'FOO' },
+    { provide: FUNCTION_TOKEN, useValue: () => 'BAR' }
+  ]
 })
 class LabelTextModule {}
 //////////////////////////
@@ -30,7 +42,10 @@ describe('simple component example', () => {
   let shallow: Shallow<LabelTextComponent>;
 
   beforeEach(() => {
-    shallow = new Shallow(LabelTextComponent, LabelTextModule).mock(STYLE_TOKEN, { defaultLabelClass: 'MOCK-CLASS' });
+    shallow = new Shallow(LabelTextComponent, LabelTextModule)
+      .mock(STYLE_TOKEN, { defaultLabelClass: 'MOCK-CLASS' })
+      .mock(STRING_TOKEN, 'MOCK-STRING')
+      .mock(FUNCTION_TOKEN, () => 'MOCK-FUNCTION');
   });
 
   it('sets the color to the configured color and size', async () => {
@@ -45,5 +60,17 @@ describe('simple component example', () => {
 
     const label = find('label');
     expect(label.nativeElement.innerText.trim()).toBe('Woot!');
+  });
+
+  it('renders the string token', async () => {
+    const { find } = await shallow.render();
+
+    expect(find('#token-string').nativeElement.innerText).toBe('MOCK-STRING');
+  });
+
+  it('renders the results of the function token', async () => {
+    const { find } = await shallow.render();
+
+    expect(find('#token-function').nativeElement.innerText).toBe('MOCK-FUNCTION');
   });
 });

--- a/lib/models/renderer.ts
+++ b/lib/models/renderer.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Type } from '@angular/core';
+import { Directive, EventEmitter, Type, InjectionToken } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { testFramework } from '../test-frameworks/test-framework';
@@ -7,7 +7,6 @@ import { createTestModule } from '../tools/create-test-module';
 import { mockProvider } from '../tools/mock-provider';
 import { directiveResolver } from '../tools/reflect';
 import { CustomError } from './custom-error';
-import { mockProviderClass } from './mock-of-provider';
 import { RecursivePartial } from './recursive-partial';
 import { Rendering, RenderOptions } from './rendering';
 import { TestSetup } from './test-setup';
@@ -132,8 +131,16 @@ export class Renderer<TComponent> {
     // This takes care of providedIn 'root'
     this._setup.mocks.forEach((mock, thingToMock) => {
       if (!directiveResolver.isDirective(thingToMock)) {
-        const MockProvider = mockProviderClass(thingToMock, mock);
-        TestBed.overrideProvider(thingToMock, { useValue: new MockProvider() });
+        if (thingToMock instanceof InjectionToken) {
+          TestBed.overrideProvider(thingToMock, { useValue: mock });
+        } else {
+          const provider = mockProvider(thingToMock, this._setup);
+          TestBed.overrideProvider(thingToMock, {
+            useValue: provider.useValue,
+            useFactory: provider.useFactory,
+            deps: provider.deps
+          });
+        }
       }
     });
 

--- a/lib/models/rendering.spec.ts
+++ b/lib/models/rendering.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, Directive, EventEmitter, Input, Output, Type } from '@angular/core';
+import { Component, DebugElement, Directive, EventEmitter, Input, Output, Type, InjectionToken } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent, MockDirective } from 'ng-mocks';
@@ -77,6 +77,7 @@ class WillBeMockedComponent {}
   template: '<span>other</span>'
 })
 class OtherComponent {}
+const MY_TOKEN = new InjectionToken<boolean>('My boolean token');
 
 describe('Rendering', () => {
   let testSetup: TestSetup<OuterComponent>;
@@ -95,6 +96,7 @@ describe('Rendering', () => {
     testSetup.mockCache.add(WillBeMockedDirective, MockedDirective);
     testSetup.mockCache.add(WillBeMockedComponent, MockedComponent);
     return TestBed.configureTestingModule({
+      providers: [{ provide: MY_TOKEN, useValue: true }],
       declarations: [
         TestHostComponent,
         OuterComponent,
@@ -374,9 +376,9 @@ describe('Rendering', () => {
 
   describe('get', () => {
     it('returns the result of TestBed.inject', () => {
+      spyOn(TestBed, 'inject').and.returnValue('foo');
       // tslint:disable-next-line: deprecation
       const { get } = new Rendering(fixture, element, instance, {}, testSetup);
-      spyOn(TestBed, 'inject').and.returnValue('foo');
 
       // tslint:disable-next-line: deprecation
       expect(get(class {})).toBe('foo');
@@ -385,10 +387,16 @@ describe('Rendering', () => {
 
   describe('inject', () => {
     it('returns the result of TestBed.inject', () => {
-      const { inject } = new Rendering(fixture, element, instance, {}, testSetup);
       spyOn(TestBed, 'inject').and.returnValue('foo');
+      const { inject } = new Rendering(fixture, element, instance, {}, testSetup);
 
       expect(inject(class {})).toBe('foo');
+    });
+
+    it('can inject InjectionTokens', () => {
+      const { inject } = new Rendering(fixture, element, instance, {}, testSetup);
+
+      expect(inject(MY_TOKEN)).toBe(true);
     });
   });
 

--- a/lib/models/rendering.ts
+++ b/lib/models/rendering.ts
@@ -1,4 +1,4 @@
-import { DebugElement, EventEmitter, Type } from '@angular/core';
+import { DebugElement, EventEmitter, Type, InjectionToken, AbstractType } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockedDirective } from 'ng-mocks';
@@ -75,10 +75,11 @@ export class Rendering<TComponent, TBindings> {
   /**
    * @deprecated Use inject instead
    */
-  readonly get = <TClass>(queryClass: Type<TClass>): TClass => TestBed.inject(queryClass);
+  readonly get = <TValue>(queryClass: Type<TValue> | InjectionToken<TValue> | AbstractType<TValue>): TValue =>
+    TestBed.inject(queryClass);
 
-  readonly inject: typeof TestBed['inject'] = (...args: Parameters<typeof TestBed['inject']>) =>
-    TestBed.inject(...args);
+  // tslint:disable-next-line: member-ordering
+  readonly inject = TestBed.inject.bind(TestBed);
 
   readonly findStructuralDirective = <TDirective>(
     directiveClass: Type<TDirective>,

--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -115,9 +115,13 @@ export class Shallow<TTestComponent> {
     return this;
   }
 
-  mock<TMock>(mockClass: Type<TMock> | InjectionToken<TMock>, stubs: RecursivePartial<TMock>): this {
-    const mock = this.setup.mocks.get(mockClass) || {};
-    this.setup.mocks.set(mockClass, { ...mock, ...(stubs as object) });
+  mock<TMock>(thingToMock: Type<TMock> | InjectionToken<TMock>, stubs: RecursivePartial<TMock>): this {
+    const mock = this.setup.mocks.get(thingToMock);
+    if (typeof mock === 'object') {
+      this.setup.mocks.set(thingToMock, { ...mock, ...(stubs as object) });
+    } else {
+      this.setup.mocks.set(thingToMock, stubs);
+    }
     return this;
   }
 

--- a/lib/tools/mock-provider.spec.ts
+++ b/lib/tools/mock-provider.spec.ts
@@ -1,4 +1,4 @@
-import { ExistingProvider, ValueProvider } from '@angular/core';
+import { ExistingProvider, ValueProvider, InjectionToken } from '@angular/core';
 import { MockOfProvider } from '../models/mock-of-provider';
 import { TestSetup } from '../models/test-setup';
 import { mockProvider } from './mock-provider';
@@ -107,5 +107,22 @@ describe('mockPrivider', () => {
     const providers = mockProvider([FooService], testSetup) as any[];
 
     expect(providers[0]).toBe(FooService);
+  });
+
+  it('mocks non-object injection tokens', () => {
+    const STRING_TOKEN = new InjectionToken<string>('My string token');
+    const FUNCTION_TOKEN = new InjectionToken<() => string>('My function token');
+    testSetup.mocks.set(STRING_TOKEN, 'FOO');
+    testSetup.mocks.set(FUNCTION_TOKEN, () => 'BAR');
+    const providers = mockProvider(
+      [
+        { provide: STRING_TOKEN, useValue: 'ORIGINAL-STRING' },
+        { provide: FUNCTION_TOKEN, useValue: () => 'ORIGINAL-FUNCTION' }
+      ],
+      testSetup
+    ) as any[];
+
+    expect(providers[0].useValue).toBe('FOO');
+    expect(providers[1].useValue()).toBe('BAR');
   });
 });

--- a/lib/tools/mock-provider.ts
+++ b/lib/tools/mock-provider.ts
@@ -1,4 +1,4 @@
-import { APP_INITIALIZER, Provider, TypeProvider, ValueProvider } from '@angular/core';
+import { APP_INITIALIZER, Provider, InjectionToken, TypeProvider, ValueProvider } from '@angular/core';
 import { mockProviderClass } from '../models/mock-of-provider';
 import { TestSetup } from '../models/test-setup';
 import { isClassProvider, isExistingProvider, isFactoryProvider, isTypeProvider } from './type-checkers';
@@ -23,6 +23,10 @@ export function mockProvider(provider: Provider, setup: TestSetup<any>): Provide
 
   const provide = isTypeProvider(provider) ? provider : provider.provide;
   const userMocks = setup.mocks.get(provide);
+
+  if (provide instanceof InjectionToken) {
+    return userMocks ? { provide, useValue: userMocks } : provider;
+  }
 
   // TODO: What if setup.dontMock.includes(provide.useClass)?
   if (!userMocks && recursiveIncludes(setup.dontMock, provide)) {


### PR DESCRIPTION
Addresses deficiencies noted in #153 

This allows mocking injection tokens directly like:

```typescript
const STRING_TOKEN = new InjectionToken<string>('A string injection token');
const FUNCTION_TOKEN = new InjectionToken<() => string>('A function injection token');

// Can now be mocked with:
shallow
  .mock(STRING_TOKEN, 'mocked value')
  .mock(FUNCTION_TOKEN, () => 'mocked function return');
```
