### PR TITLE
fix(176): Fix recursion issues when mocking components

### DIFF
--- a/lib/examples/component-with-forms.spec.ts
+++ b/lib/examples/component-with-forms.spec.ts
@@ -43,6 +43,7 @@ describe('component with forms', () => {
     shallow = new Shallow(FooComponent, FooModule).provideMock({
       provide: NG_VALUE_ACCESSOR,
       useClass: DefaultValueAccessor,
+      multi: true,
     });
   });
 

--- a/lib/tools/create-test-module.ts
+++ b/lib/tools/create-test-module.ts
@@ -31,7 +31,7 @@ export function createTestModule<TComponent>(setup: TestSetup<TComponent>, testC
     imports: [...ngMock([...ngModule.imports, ...setup.imports], setup), CommonModule],
     declarations: [...declarations, ...testComponents],
     entryComponents,
-    providers: [...ngModule.providers, ...additionalProviders, ...setup.providers].map(p => mockProvider(p, setup)),
+    providers: mockProvider([...ngModule.providers, ...additionalProviders, ...setup.providers], setup),
     exports: [...declarations, ...entryComponents],
     schemas: ngModule.schemas || [],
   })

--- a/lib/tools/mock-with-inputs-and-outputs-and-stubs.ts
+++ b/lib/tools/mock-with-inputs-and-outputs-and-stubs.ts
@@ -1,19 +1,15 @@
 import { Input, Output, EventEmitter, Type } from '@angular/core';
 import { directiveResolver } from './reflect';
 import { MockWithStubs } from '../models/mock-with-stubs';
-import { ControlValueAccessor } from '@angular/forms';
 
 export const mockWithInputsOutputsAndStubs = (componentOrDirective: Type<any>, stubs?: object): Type<any> => {
   const { inputs, outputs } = directiveResolver.resolve(componentOrDirective);
 
-  class Mock extends MockWithStubs implements ControlValueAccessor {
+  class Mock extends MockWithStubs {
     constructor() {
       super(stubs);
       outputs?.map(output => output.split(': ')).forEach(([key]) => Object.assign(this, { [key]: new EventEmitter() }));
     }
-    writeValue(_obj: any): void {}
-    registerOnChange(_fn: any): void {}
-    registerOnTouched(_fn: any): void {}
   }
 
   inputs?.map(input => input.split(': ')).forEach(([key, alias]) => Input(alias)(Mock.prototype, key));

--- a/lib/tools/ng-mock.ts
+++ b/lib/tools/ng-mock.ts
@@ -37,7 +37,7 @@ export function ngMock<TThing extends NgMockable | NgMockable[]>(thing: TThing, 
       mock = mockPipe(thing, setup.mockPipes.get(thing));
     } else if (isClass(thing)) {
       const stubs = setup.mocks.get(thing);
-      const providerTransform = (providers: Provider[]) => providers.map(p => mockProvider(p, setup));
+      const providerTransform = (providers: Provider[]) => mockProvider(providers, setup);
       mock =
         declarationType(thing) === 'Component'
           ? mockComponent(thing, { stubs, providerTransform })


### PR DESCRIPTION
BugFix for issue reported in #176.

No new features, just had a regression when mocking providers that caused tests with certain kinds of module structures to overflow the stack!

Realized a few more cleanups along the way.