### PR TITLE
feat: Native support for service testing

### DIFF
--- a/lib/examples/service-only-testing.spec.ts
+++ b/lib/examples/service-only-testing.spec.ts
@@ -1,0 +1,69 @@
+import { Injectable, NgModule } from '@angular/core';
+import { Shallow } from '../shallow';
+import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+
+////// Module Setup //////
+
+type WeatherServiceResults = {
+  chanceOfRain: number;
+  temperature: number;
+};
+
+@Injectable()
+class WeatherService {
+  constructor(private _http: HttpClient) {}
+
+  getTemperatureForZip(zipcode: string) {
+    return this._http
+      .get<WeatherServiceResults>('https://my-weather-api.com', { params: { zipcode } })
+      .toPromise()
+      .then(result => result.temperature);
+  }
+}
+
+@NgModule({
+  providers: [WeatherService],
+  imports: [HttpClientModule],
+})
+class WeatherModule {}
+//////////////////////////
+
+describe('WeatherService', () => {
+  let shallow: Shallow<WeatherService>;
+
+  beforeEach(() => {
+    shallow = new Shallow(WeatherService, WeatherModule);
+  });
+
+  describe('getTemperatureForZip', () => {
+    ////////////////////////
+    // With Standard Mocks
+    ////////////////////////
+    it('returns the temperature for the given zipcode', async () => {
+      const { inject, instance } = shallow.mock(HttpClient, { get: () => of({ temperature: 20 }) }).createService();
+      const temperature = await instance.getTemperatureForZip('12345');
+
+      expect(inject(HttpClient).get).toHaveBeenCalledWith(jasmine.stringMatching('my-weather-api.com'), {
+        params: { zipcode: '12345' },
+      });
+      expect(temperature).toBe(20);
+    });
+
+    /////////////////////////////////
+    // With HttpClientTestingModule
+    /////////////////////////////////
+    it('returns the temperature for the given zipcode', async () => {
+      const { inject, instance } = shallow.replaceModule(HttpClientModule, HttpClientTestingModule).createService();
+      const http = inject(HttpTestingController);
+      const requestPromise = instance.getTemperatureForZip('12345');
+      const mock = http.expectOne('https://my-weather-api.com?zipcode=12345');
+
+      expect(mock.request.method).toBe('GET');
+      mock.flush({ temperature: 20 });
+      expect(await requestPromise).toBe(20);
+      http.verify();
+    });
+  });
+});

--- a/lib/examples/using-replacement-modules.spec.ts
+++ b/lib/examples/using-replacement-modules.spec.ts
@@ -39,7 +39,7 @@ describe('using replaceModule', () => {
 
   it('displays the response from the foo service', fakeAsync(async () => {
     const { element, inject, fixture } = await shallow.render();
-    const client = inject(HttpTestingController as Type<HttpTestingController>);
+    const client = inject(HttpTestingController);
     client.expectOne('/foo/as/a/service').flush('foo response');
     tick();
     fixture.detectChanges();
@@ -49,7 +49,7 @@ describe('using replaceModule', () => {
 
   it('displays ERROR when a service error occurs', fakeAsync(async () => {
     const { element, inject, fixture } = await shallow.render();
-    const client = inject(HttpTestingController as Type<HttpTestingController>);
+    const client = inject(HttpTestingController);
     client.expectOne('/foo/as/a/service').error(new ErrorEvent('BOOM'));
     tick();
     fixture.detectChanges();

--- a/lib/models/custom-error.spec.ts
+++ b/lib/models/custom-error.spec.ts
@@ -4,13 +4,13 @@ describe('CustomError', () => {
   it('is an instanceof Error', () => {
     const error = new CustomError('foo');
 
-    expect(error instanceof Error).toBe(true);
+    expect(error).toBeInstanceOf(Error);
   });
 
   it('is an instanceof CustomError', () => {
     const error = new CustomError('foo');
 
-    expect(error instanceof CustomError).toBe(true);
+    expect(error).toBeInstanceOf(CustomError);
   });
 
   it('has has the correct message', () => {

--- a/lib/models/query-match.spec.ts
+++ b/lib/models/query-match.spec.ts
@@ -12,7 +12,7 @@ describe('QueryMatch', () => {
       func();
       fail(`Should have thrown an ${errorClass.name} error`);
     } catch (e) {
-      expect(e instanceof errorClass).toBe(true);
+      expect(e).toBeInstanceOf(errorClass);
     }
   };
   describe('single match', () => {
@@ -40,7 +40,7 @@ describe('QueryMatch', () => {
     });
 
     it('passes the instanceof check for the first object', () => {
-      expect(match instanceof Foo).toBe(true);
+      expect(match).toBeInstanceOf(Foo);
     });
 
     it('allows checking individual object keys', () => {

--- a/lib/models/renderer.spec.ts
+++ b/lib/models/renderer.spec.ts
@@ -11,13 +11,9 @@ import {
   InjectionToken,
   Injectable,
 } from '@angular/core';
-import {
-  InvalidBindOnEntryComponentError,
-  InvalidInputBindError,
-  InvalidStaticPropertyMockError,
-  Renderer,
-} from './renderer';
+import { InvalidBindOnEntryComponentError, InvalidInputBindError, Renderer } from './renderer';
 import { TestSetup } from './test-setup';
+import { InvalidStaticPropertyMockError } from '../tools/mock-statics';
 
 class TestUtility {
   // tslint:disable-line no-unnecessary-class
@@ -89,7 +85,7 @@ describe('Renderer', () => {
       await renderer.render();
       fail('render should have thrown an error');
     } catch (e) {
-      expect(e instanceof InvalidStaticPropertyMockError).toBe(true);
+      expect(e).toBeInstanceOf(InvalidStaticPropertyMockError);
     }
   });
 
@@ -100,7 +96,7 @@ describe('Renderer', () => {
       await renderer.render();
       fail('render should have thrown an error');
     } catch (e) {
-      expect(e instanceof InvalidStaticPropertyMockError).toBe(true);
+      expect(e).toBeInstanceOf(InvalidStaticPropertyMockError);
     }
   });
 
@@ -127,7 +123,7 @@ describe('Renderer', () => {
     it('wraps the rendering in a container', async () => {
       const { fixture } = await renderer.render('<thing></thing>');
 
-      expect(fixture.debugElement.children[0].componentInstance instanceof TestComponent).toBe(true);
+      expect(fixture.debugElement.children[0].componentInstance).toBeInstanceOf(TestComponent);
     });
   });
 
@@ -135,7 +131,7 @@ describe('Renderer', () => {
     it('wraps the rendering in a container', async () => {
       const { fixture } = await renderer.render();
 
-      expect(fixture.debugElement.children[0].componentInstance instanceof TestComponent).toBe(true);
+      expect(fixture.debugElement.children[0].componentInstance).toBeInstanceOf(TestComponent);
     });
   });
 
@@ -143,7 +139,7 @@ describe('Renderer', () => {
     it('wraps the rendering in a container', async () => {
       const { fixture } = await renderer.render({});
 
-      expect(fixture.debugElement.children[0].componentInstance instanceof TestComponent).toBe(true);
+      expect(fixture.debugElement.children[0].componentInstance).toBeInstanceOf(TestComponent);
     });
 
     it('binds through the wrapper to the component', async () => {
@@ -168,7 +164,7 @@ describe('Renderer', () => {
         });
         fail('Render should have thrown an error because the myProperty is not an @Input');
       } catch (e) {
-        expect(e instanceof InvalidInputBindError).toBe(true);
+        expect(e).toBeInstanceOf(InvalidInputBindError);
         done();
       }
     });
@@ -263,7 +259,7 @@ describe('Renderer', () => {
       const myRenderer = new Renderer(new TestSetup(IfOddDirective, OddModule));
       const { instance } = await myRenderer.render('<b *ifOdd="2"></b>');
 
-      expect(instance instanceof IfOddDirective).toBe(true);
+      expect(instance).toBeInstanceOf(IfOddDirective);
     });
   });
 
@@ -349,7 +345,7 @@ describe('Renderer', () => {
         });
         fail('Should not have rendered the entry component');
       } catch (e) {
-        expect(e instanceof InvalidBindOnEntryComponentError).toBe(true);
+        expect(e).toBeInstanceOf(InvalidBindOnEntryComponentError);
       }
     });
 

--- a/lib/models/rendering.spec.ts
+++ b/lib/models/rendering.spec.ts
@@ -216,7 +216,7 @@ describe('Rendering', () => {
     it('finds components', () => {
       const { findComponent } = new Rendering(fixture, element, instance, {}, testSetup);
 
-      expect(findComponent(InnerComponent) instanceof InnerComponent).toBe(true);
+      expect(findComponent(InnerComponent)).toBeInstanceOf(InnerComponent);
     });
 
     it('finds mocked components', () => {
@@ -230,7 +230,7 @@ describe('Rendering', () => {
 
       const found = findComponent(OtherComponent);
       expect(found).toHaveFound(2);
-      found.forEach(i => expect(i instanceof OtherComponent).toBe(true));
+      found.forEach(i => expect(i).toBeInstanceOf(OtherComponent));
     });
 
     it('finds components that match a css query', () => {
@@ -252,7 +252,7 @@ describe('Rendering', () => {
     it('finds directives', () => {
       const { findDirective } = new Rendering(fixture, element, instance, {}, testSetup);
 
-      expect(findDirective(TestDirective) instanceof TestDirective).toBe(true);
+      expect(findDirective(TestDirective)).toBeInstanceOf(TestDirective);
     });
 
     it('finds mocked directives', () => {
@@ -266,7 +266,7 @@ describe('Rendering', () => {
 
       const found = findDirective(OtherDirective);
       expect(found).toHaveFound(2);
-      found.forEach(i => expect(i instanceof OtherDirective).toBe(true));
+      found.forEach(i => expect(i).toBeInstanceOf(OtherDirective));
     });
 
     it('finds directives that match a css query', () => {
@@ -422,7 +422,7 @@ describe('Rendering', () => {
     it('returns properties that are eventEmitters', () => {
       const rendering = new Rendering(fixture, element, instance, {}, testSetup);
 
-      expect(rendering.outputs.markedAsOutput instanceof EventEmitter).toBe(true);
+      expect(rendering.outputs.markedAsOutput).toBeInstanceOf(EventEmitter);
     });
 
     it('raises an error when accessing an output that is not decorated properly', () => {

--- a/lib/models/test-setup.spec.ts
+++ b/lib/models/test-setup.spec.ts
@@ -1,4 +1,0 @@
-describe('TestSetup', () => {
-  // it('does nothing special', () => {
-  // });
-});

--- a/lib/models/test-setup.ts
+++ b/lib/models/test-setup.ts
@@ -2,7 +2,7 @@ import { PipeTransform, Provider, Type } from '@angular/core';
 import { AngularModule } from './angular-module';
 import { MockCache } from './mock-cache';
 
-export class TestSetup<TComponent> {
+export class TestSetup<TTestTarget> {
   readonly dontMock: any[] = [];
   readonly mocks = new Map();
   readonly staticMocks = new Map();
@@ -15,5 +15,5 @@ export class TestSetup<TComponent> {
   readonly withStructuralDirectives = new Map<Type<any>, boolean>();
   public alwaysRenderStructuralDirectives = false;
 
-  constructor(public readonly testComponent: Type<TComponent>, public readonly testModule: AngularModule) {}
+  constructor(public readonly testComponentOrService: Type<TTestTarget>, public readonly testModule: AngularModule) {}
 }

--- a/lib/shallow.spec.ts
+++ b/lib/shallow.spec.ts
@@ -1,8 +1,9 @@
 import { Component, InjectionToken, NgModule, Pipe, PipeTransform } from '@angular/core';
-import { InvalidStaticPropertyMockError } from './models/renderer';
 import { Shallow } from './shallow';
+import { InvalidStaticPropertyMockError } from './tools/mock-statics';
+import { CustomError } from './models/custom-error';
 
-class TestService {
+class MyTestService {
   static staticFoo() {
     return 'static foo';
   }
@@ -17,34 +18,35 @@ class TestService {
   }
 }
 @Component({
-  selector: 'test',
+  selector: 'my-test-component',
   template: '<hr/>',
 })
-class TestComponent {}
+class MyTestComponent {}
 
-@Pipe({ name: 'test' })
-class TestPipe implements PipeTransform {
+@Pipe({ name: 'myTestPipe' })
+class MyTestPipe implements PipeTransform {
   transform() {
     return { test: 'pipe' };
   }
 }
 
 @NgModule({
-  declarations: [TestComponent, TestPipe],
+  declarations: [MyTestComponent, MyTestPipe],
+  providers: [MyTestService],
 })
-class TestModule {}
+class MyTestModule {}
 
 describe('Shallow', () => {
-  it('includes the testComponent in setup.dontMock', () => {
-    const shallow = new Shallow(TestComponent, TestModule);
+  it('includes the test component in setup.dontMock', () => {
+    const shallow = new Shallow(MyTestComponent, MyTestModule);
 
-    expect(shallow.setup.dontMock).toContain(TestComponent);
+    expect(shallow.setup.dontMock).toContain(MyTestComponent);
   });
 
   describe('neverMock', () => {
     it('items are automatically added to setup.dontMock on construction', () => {
       Shallow.neverMock('NEVER_MOCKED');
-      const shallow = new Shallow(TestComponent, TestModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule);
 
       expect(shallow.setup.dontMock).toContain('NEVER_MOCKED');
     });
@@ -54,7 +56,7 @@ describe('Shallow', () => {
     it('automatically adds items to setup.provide on construction', () => {
       class MyService {}
       Shallow.alwaysProvide(MyService);
-      const shallow = new Shallow(TestComponent, TestModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule);
 
       expect(shallow.setup.providers).toContain(MyService);
     });
@@ -63,18 +65,18 @@ describe('Shallow', () => {
   describe('alwaysReplaceModule', () => {
     it('automatically adds modules to setup.replacementModules on construction', () => {
       class ReplacementModule {}
-      Shallow.alwaysReplaceModule(TestModule, ReplacementModule);
-      const shallow = new Shallow(TestComponent, TestModule);
+      Shallow.alwaysReplaceModule(MyTestModule, ReplacementModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule);
 
-      expect(shallow.setup.moduleReplacements.get(TestModule)).toBe(ReplacementModule);
+      expect(shallow.setup.moduleReplacements.get(MyTestModule)).toBe(ReplacementModule);
     });
 
     it('works with ModuleWithProviders', () => {
       const replacementModule = { ngModule: class {}, providers: [] };
-      Shallow.alwaysReplaceModule(TestModule, replacementModule);
-      const shallow = new Shallow(TestComponent, TestModule);
+      Shallow.alwaysReplaceModule(MyTestModule, replacementModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule);
 
-      expect(shallow.setup.moduleReplacements.get(TestModule)).toBe(replacementModule);
+      expect(shallow.setup.moduleReplacements.get(MyTestModule)).toBe(replacementModule);
     });
   });
 
@@ -83,7 +85,7 @@ describe('Shallow', () => {
       @NgModule({})
       class MyModule {}
       Shallow.alwaysImport(MyModule);
-      const shallow = new Shallow(TestComponent, TestModule);
+      const shallow = new Shallow(MyTestComponent, MyModule);
 
       expect(shallow.setup.imports).toContain(MyModule);
     });
@@ -97,7 +99,7 @@ describe('Shallow', () => {
         }
       }
       Shallow.alwaysMock(MyService, { foo: () => 'mock foo' });
-      const shallow = new Shallow(TestComponent, TestModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule);
 
       expect(shallow.setup.mocks.get(MyService).foo()).toBe('mock foo');
     });
@@ -111,7 +113,7 @@ describe('Shallow', () => {
       const myToken = new InjectionToken<MyService>('My Service token');
       const myMock = { myNumericMethod: () => 5 };
       Shallow.alwaysMock(myToken, myMock);
-      const shallow = new Shallow(TestComponent, TestModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule);
 
       expect(shallow.setup.mocks.get(myToken)).toEqual(myMock);
     });
@@ -130,7 +132,7 @@ describe('Shallow', () => {
         bar: () => 'always mock bar',
       };
       Shallow.alwaysMock(MyService, alwaysMock);
-      const shallow = new Shallow(TestComponent, TestModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule);
       shallow.mock(MyService, { foo: () => 'second foo' });
       const secondMock = shallow.setup.mocks.get(MyService);
 
@@ -149,7 +151,7 @@ describe('Shallow', () => {
         }
       }
       Shallow.alwaysMockPipe(MyPipe, () => 'mock foo');
-      const shallow = new Shallow(TestComponent, TestModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule);
 
       expect(shallow.setup.mockPipes.get(MyPipe)?.()).toBe('mock foo');
     });
@@ -161,7 +163,7 @@ describe('Shallow', () => {
       class DummyFalseDirective {}
       Shallow.alwaysWithStructuralDirective(DummyDirective, true);
       Shallow.alwaysWithStructuralDirective(DummyFalseDirective, false);
-      const shallow = new Shallow(TestComponent, TestModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule);
 
       expect(shallow.setup.withStructuralDirectives.get(DummyDirective)).toBe(true);
       expect(shallow.setup.withStructuralDirectives.get(DummyFalseDirective)).toBe(false);
@@ -170,7 +172,7 @@ describe('Shallow', () => {
 
   describe('dontMock', () => {
     it('adds things to setup.dontMock', () => {
-      const shallow = new Shallow(TestComponent, TestModule).dontMock('foo');
+      const shallow = new Shallow(MyTestComponent, MyTestModule).dontMock('foo');
 
       expect(shallow.setup.dontMock).toContain('foo');
     });
@@ -179,7 +181,7 @@ describe('Shallow', () => {
   describe('provide', () => {
     it('adds to the setup.providers array', () => {
       class MyService {}
-      const shallow = new Shallow(TestComponent, TestModule).provide(MyService);
+      const shallow = new Shallow(MyTestComponent, MyTestModule).provide(MyService);
 
       expect(shallow.setup.providers).toContain(MyService);
     });
@@ -188,7 +190,7 @@ describe('Shallow', () => {
   describe('provideMock', () => {
     it('adds to the setup.providers and setup.dontMock', () => {
       class MyService {}
-      const shallow = new Shallow(TestComponent, TestModule).provideMock(MyService);
+      const shallow = new Shallow(MyTestComponent, MyTestModule).provideMock(MyService);
 
       expect(shallow.setup.providers).toContain(MyService);
       expect(shallow.setup.dontMock).toContain(MyService);
@@ -198,7 +200,7 @@ describe('Shallow', () => {
   describe('declare', () => {
     it('adds to the setup.declarations array', () => {
       class MyComponent {}
-      const shallow = new Shallow(TestComponent, TestModule).declare(MyComponent);
+      const shallow = new Shallow(MyComponent, MyTestModule).declare(MyComponent);
 
       expect(shallow.setup.declarations).toContain(MyComponent);
     });
@@ -208,7 +210,7 @@ describe('Shallow', () => {
     it('adds to the setup.imports array', () => {
       @NgModule({})
       class MyModule {}
-      const shallow = new Shallow(TestComponent, TestModule).import(MyModule);
+      const shallow = new Shallow(MyTestComponent, MyModule).import(MyModule);
 
       expect(shallow.setup.imports).toContain(MyModule);
     });
@@ -216,26 +218,26 @@ describe('Shallow', () => {
 
   describe('mock', () => {
     it('adds a mock to the mocks', () => {
-      const shallow = new Shallow(TestComponent, TestModule).mock(TestService, { foo: () => 'mocked foo' });
+      const shallow = new Shallow(MyTestComponent, MyTestModule).mock(MyTestService, { foo: () => 'mocked foo' });
 
-      expect(shallow.setup.mocks.get(TestService).foo()).toBe('mocked foo');
+      expect(shallow.setup.mocks.get(MyTestService).foo()).toBe('mocked foo');
     });
 
     it('adds mocks on mocks', () => {
-      const shallow = new Shallow(TestComponent, TestModule)
-        .mock(TestService, { foo: () => 'mocked foo' })
-        .mock(TestService, { foo: () => 'mocked foo two' });
+      const shallow = new Shallow(MyTestComponent, MyTestModule)
+        .mock(MyTestService, { foo: () => 'mocked foo' })
+        .mock(MyTestService, { foo: () => 'mocked foo two' });
 
-      expect(shallow.setup.mocks.get(TestService).foo()).toBe('mocked foo two');
+      expect(shallow.setup.mocks.get(MyTestService).foo()).toBe('mocked foo two');
     });
 
     it('adds mocks to mocks', () => {
-      const shallow = new Shallow(TestComponent, TestModule)
-        .mock(TestService, { foo: () => 'mocked foo' })
-        .mock(TestService, { bar: () => 'mocked bar' });
+      const shallow = new Shallow(MyTestComponent, MyTestModule)
+        .mock(MyTestService, { foo: () => 'mocked foo' })
+        .mock(MyTestService, { bar: () => 'mocked bar' });
 
-      expect(shallow.setup.mocks.get(TestService).foo()).toBe('mocked foo');
-      expect(shallow.setup.mocks.get(TestService).bar()).toBe('mocked bar');
+      expect(shallow.setup.mocks.get(MyTestService).foo()).toBe('mocked foo');
+      expect(shallow.setup.mocks.get(MyTestService).bar()).toBe('mocked bar');
     });
   });
 
@@ -245,40 +247,42 @@ describe('Shallow', () => {
         staticNumber: 999,
       };
 
-      expect(() => new Shallow(TestComponent, TestModule).mockStatic(staticObject, { staticNumber: 999 })).toThrow(
+      expect(() => new Shallow(MyTestComponent, MyTestModule).mockStatic(staticObject, { staticNumber: 999 })).toThrow(
         new InvalidStaticPropertyMockError('staticNumber')
       );
     });
 
     it('adds a static mock to the staticMocks', () => {
-      const shallow = new Shallow(TestComponent, TestModule).mockStatic(TestService, { staticFoo: () => 'mocked foo' });
+      const shallow = new Shallow(MyTestComponent, MyTestModule).mockStatic(MyTestService, {
+        staticFoo: () => 'mocked foo',
+      });
 
-      expect(shallow.setup.staticMocks.get(TestService).staticFoo()).toBe('mocked foo');
+      expect(shallow.setup.staticMocks.get(MyTestService).staticFoo()).toBe('mocked foo');
     });
 
     it('adds mocks on mocks', () => {
-      const shallow = new Shallow(TestComponent, TestModule)
-        .mockStatic(TestService, { staticFoo: () => 'mocked foo' })
-        .mockStatic(TestService, { staticFoo: () => 'mocked foo two' });
+      const shallow = new Shallow(MyTestComponent, MyTestModule)
+        .mockStatic(MyTestService, { staticFoo: () => 'mocked foo' })
+        .mockStatic(MyTestService, { staticFoo: () => 'mocked foo two' });
 
-      expect(shallow.setup.staticMocks.get(TestService).staticFoo()).toBe('mocked foo two');
+      expect(shallow.setup.staticMocks.get(MyTestService).staticFoo()).toBe('mocked foo two');
     });
 
     it('adds mocks to mocks', () => {
-      const shallow = new Shallow(TestComponent, TestModule)
-        .mockStatic(TestService, { staticFoo: () => 'mocked foo' })
-        .mockStatic(TestService, { staticBar: () => 'mocked bar' });
+      const shallow = new Shallow(MyTestComponent, MyTestModule)
+        .mockStatic(MyTestService, { staticFoo: () => 'mocked foo' })
+        .mockStatic(MyTestService, { staticBar: () => 'mocked bar' });
 
-      expect(shallow.setup.staticMocks.get(TestService).staticFoo()).toBe('mocked foo');
-      expect(shallow.setup.staticMocks.get(TestService).staticBar()).toBe('mocked bar');
+      expect(shallow.setup.staticMocks.get(MyTestService).staticFoo()).toBe('mocked foo');
+      expect(shallow.setup.staticMocks.get(MyTestService).staticBar()).toBe('mocked bar');
     });
   });
 
   describe('mockPipe', () => {
     it('adds pipe mocks with specific transforms', () => {
-      const shallow = new Shallow(TestComponent, TestModule).mockPipe(TestPipe, () => ({ test: 'mocked pipe' }));
+      const shallow = new Shallow(MyTestComponent, MyTestModule).mockPipe(MyTestPipe, () => ({ test: 'mocked pipe' }));
 
-      const transform = shallow.setup.mockPipes.get(TestPipe);
+      const transform = shallow.setup.mockPipes.get(MyTestPipe);
       expect(transform && transform()).toEqual({ test: 'mocked pipe' });
     });
   });
@@ -286,9 +290,9 @@ describe('Shallow', () => {
   describe('replaceModule', () => {
     it('adds replacementModule', () => {
       class ReplacementModule {}
-      const shallow = new Shallow(TestComponent, TestModule).replaceModule(TestModule, ReplacementModule);
+      const shallow = new Shallow(MyTestComponent, MyTestModule).replaceModule(MyTestModule, ReplacementModule);
 
-      expect(shallow.setup.moduleReplacements.get(TestModule)).toBe(ReplacementModule);
+      expect(shallow.setup.moduleReplacements.get(MyTestModule)).toBe(ReplacementModule);
     });
   });
 
@@ -296,7 +300,7 @@ describe('Shallow', () => {
     it('adds the directive to the test setup', () => {
       class DummyDirective {}
       class DummyFalseDirective {}
-      const shallow = new Shallow(TestComponent, TestModule)
+      const shallow = new Shallow(MyTestComponent, MyTestModule)
         .withStructuralDirective(DummyDirective, true)
         .withStructuralDirective(DummyFalseDirective, false);
 
@@ -307,21 +311,32 @@ describe('Shallow', () => {
 
   describe('render', () => {
     it('can render with only HTML', async () => {
-      const { instance } = await new Shallow(TestComponent, TestModule).render('<test></test>');
+      const { instance } = await new Shallow(MyTestComponent, MyTestModule).render(
+        '<my-test-component></my-test-component>'
+      );
 
-      expect(instance instanceof TestComponent).toBe(true);
+      expect(instance).toBeInstanceOf(MyTestComponent);
     });
 
     it('can render with no parameters', async () => {
-      const { instance } = await new Shallow(TestComponent, TestModule).render();
+      const { instance } = await new Shallow(MyTestComponent, MyTestModule).render();
 
-      expect(instance instanceof TestComponent).toBe(true);
+      expect(instance).toBeInstanceOf(MyTestComponent);
     });
 
     it('can render with only renderOptions', async () => {
-      const { instance } = await new Shallow(TestComponent, TestModule).render({ detectChanges: false });
+      const { instance } = await new Shallow(MyTestComponent, MyTestModule).render({ detectChanges: false });
 
-      expect(instance instanceof TestComponent).toBe(true);
+      expect(instance).toBeInstanceOf(MyTestComponent);
+    });
+  });
+
+  describe('createService', () => {
+    it('creates an instance of a service', () => {
+      const shallow = new Shallow(MyTestService, MyTestModule);
+      const { instance } = shallow.createService();
+
+      expect(instance).toBeInstanceOf(MyTestService);
     });
   });
 });

--- a/lib/tools/create-service.spec.ts
+++ b/lib/tools/create-service.spec.ts
@@ -1,0 +1,46 @@
+import { Injectable, NgModule } from '@angular/core';
+import { createService } from './create-service';
+import { TestSetup } from '../models/test-setup';
+
+describe('createService', () => {
+  it('return a real instance of the service', () => {
+    @Injectable()
+    class MyService {
+      foo() {
+        return 'FOO';
+      }
+    }
+
+    @NgModule({
+      providers: [MyService],
+    })
+    class MyModule {}
+
+    const setup = new TestSetup(MyService, MyModule);
+    setup.dontMock.push(MyService);
+    const { instance } = createService(setup);
+
+    expect(instance).toBeInstanceOf(MyService);
+    expect(instance.foo()).toBe('FOO');
+  });
+
+  it('mocks static properties', () => {
+    @Injectable()
+    class MyService {
+      static staticFoo() {
+        return 'STATIC FOO';
+      }
+    }
+
+    @NgModule({
+      providers: [MyService],
+    })
+    class MyModule {}
+
+    const setup = new TestSetup(MyService, MyModule);
+    setup.staticMocks.set(MyService, { staticFoo: () => 'MOCKED FOO' });
+    createService(setup);
+
+    expect(MyService.staticFoo()).toBe('MOCKED FOO');
+  });
+});

--- a/lib/tools/create-service.ts
+++ b/lib/tools/create-service.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { createTestModule } from './create-test-module';
+import { mockStatics } from './mock-statics';
+import { injectRootProviders } from './inject-root-providers';
+import { TestSetup } from '../models/test-setup';
+
+export const createService = <TService>(setup: TestSetup<TService>) => {
+  mockStatics(setup);
+  injectRootProviders(setup);
+
+  TestBed.configureTestingModule({ imports: [createTestModule(setup)] });
+
+  return {
+    instance: TestBed.inject(setup.testComponentOrService),
+    inject: TestBed.inject.bind(TestBed),
+  };
+};

--- a/lib/tools/create-test-module.ts
+++ b/lib/tools/create-test-module.ts
@@ -7,7 +7,10 @@ import { mockProvider } from './mock-provider';
 import { ngMock } from './ng-mock';
 import { isModuleWithProviders } from './type-checkers';
 
-export function createTestModule<TComponent>(setup: TestSetup<TComponent>, testComponents: any[]): AngularModule {
+export function createTestModule<TComponent>(
+  setup: TestSetup<TComponent>,
+  testComponents: Type<any>[] = []
+): AngularModule {
   let mod: Type<any>;
   let additionalProviders: Provider[] = [];
   if (isModuleWithProviders(setup.testModule)) {
@@ -18,13 +21,13 @@ export function createTestModule<TComponent>(setup: TestSetup<TComponent>, testC
   }
   const ngModule = getNgModuleAnnotations(mod);
 
+  const declarations = ngMock(
+    [...ngModule.declarations, ...setup.declarations].filter(d => d !== setup.testComponentOrService),
+    setup
+  );
   // Test Modules cannot directly define entryComponents. To work around this,
   // we create a new module which declares/exports all entryComponents and import
   // the module into the TestModule.
-  const declarations = ngMock(
-    [...ngModule.declarations, ...setup.declarations].filter(d => d !== setup.testComponent),
-    setup
-  );
   const entryComponents = [...ngMock([...ngModule.entryComponents], setup), ...setup.declarations];
 
   @NgModule({

--- a/lib/tools/inject-root-providers.ts
+++ b/lib/tools/inject-root-providers.ts
@@ -1,0 +1,22 @@
+import { TestSetup } from '../models/test-setup';
+import { directiveResolver } from './reflect';
+import { InjectionToken } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { mockProvider } from './mock-provider';
+
+export const injectRootProviders = (setup: TestSetup<any>) => {
+  setup.mocks.forEach((mock, thingToMock) => {
+    if (!directiveResolver.isDirective(thingToMock)) {
+      if (thingToMock instanceof InjectionToken) {
+        TestBed.overrideProvider(thingToMock, { useValue: mock });
+      } else {
+        const provider = mockProvider(thingToMock, setup);
+        TestBed.overrideProvider(thingToMock, {
+          useValue: provider.useValue,
+          useFactory: provider.useFactory,
+          deps: provider.deps,
+        });
+      }
+    }
+  });
+};

--- a/lib/tools/mock-component.spec.ts
+++ b/lib/tools/mock-component.spec.ts
@@ -16,7 +16,7 @@ describe('mockComponent', () => {
     }).createComponent(TestHost);
     const instance = fixture.debugElement.query(By.css('my-component')).componentInstance;
 
-    expect(instance instanceof MyMock).toBe(true);
+    expect(instance).toBeInstanceOf(MyMock);
   });
 
   it('mocks inputs', () => {

--- a/lib/tools/mock-directive.spec.ts
+++ b/lib/tools/mock-directive.spec.ts
@@ -16,7 +16,7 @@ describe('mockDirective', () => {
     }).createComponent(TestHost);
     const instance = fixture.debugElement.query(By.css('div')).injector.get(MyDirective);
 
-    expect(instance instanceof MyMock).toBe(true);
+    expect(instance).toBeInstanceOf(MyMock);
   });
 
   it('mocks inputs', () => {

--- a/lib/tools/mock-provider.spec.ts
+++ b/lib/tools/mock-provider.spec.ts
@@ -36,7 +36,7 @@ describe('mockPrivider', () => {
   it('auto-mocks TypeProviders', () => {
     const provider = mockProvider(FooService, testSetup) as ValueProvider;
 
-    expect(provider.useValue instanceof MockOfProvider).toBe(true);
+    expect(provider.useValue).toBeInstanceOf(MockOfProvider);
   });
 
   it('auto-mocks ClassProviders', () => {
@@ -44,14 +44,14 @@ describe('mockPrivider', () => {
 
     expect(provider.provide).toBe(FooService);
     const instance = new provider.useClass();
-    expect(instance instanceof MockOfProvider).toBe(true);
+    expect(instance).toBeInstanceOf(MockOfProvider);
   });
 
   it('auto-mocks ValueProviders', () => {
     const provider = mockProvider({ provide: FooService, useValue: {} }, testSetup);
 
     expect(provider.provide).toBe(FooService);
-    expect(provider.useValue instanceof MockOfProvider).toBe(true);
+    expect(provider.useValue).toBeInstanceOf(MockOfProvider);
   });
 
   it('auto-mocks FactoryProviders', () => {
@@ -59,7 +59,7 @@ describe('mockPrivider', () => {
 
     expect(provider.provide).toBe(FooService);
     const instance = provider.useFactory();
-    expect(instance instanceof MockOfProvider).toBe(true);
+    expect(instance).toBeInstanceOf(MockOfProvider);
   });
 
   it('passes through ExistingProviders', () => {
@@ -102,7 +102,7 @@ describe('mockPrivider', () => {
     expect(providers[0]).toBe(FooService);
     // BarService was mocked
     expect(providers[1].provide).toBe(BarService);
-    expect(providers[1].useValue instanceof MockOfProvider).toBe(true);
+    expect(providers[1].useValue).toBeInstanceOf(MockOfProvider);
   });
 
   it('does not mock various provider types found in the module or in the dontMock array', () => {
@@ -191,7 +191,7 @@ describe('mockPrivider', () => {
     class Foo {}
     const provider = mockProvider({ provide: new InjectionToken<Foo>('Foo Token'), useClass: Foo }, testSetup);
 
-    expect(new provider.useClass() instanceof MockOfProvider).toBe(true);
+    expect(new provider.useClass()).toBeInstanceOf(MockOfProvider);
     expect(provider.useClass.name).toBe('MockOfFoo');
   });
 

--- a/lib/tools/mock-statics.ts
+++ b/lib/tools/mock-statics.ts
@@ -1,0 +1,33 @@
+import { CustomError } from '../models/custom-error';
+import { TestSetup } from '../models/test-setup';
+import { testFramework } from '../test-frameworks/test-framework';
+
+export class InvalidStaticPropertyMockError extends CustomError {
+  static checkMockForStaticProperties(stubs: object) {
+    Object.keys(stubs).forEach(key => {
+      if (typeof (stubs as any)[key] !== 'function') {
+        throw new InvalidStaticPropertyMockError(key);
+      }
+    });
+  }
+
+  constructor(key: string | symbol) {
+    super(`Tried to mock the '${String(key)}' property but only functions are supported for static mocks.`);
+  }
+}
+
+export const mockStatics = (setup: TestSetup<any>) => {
+  setup.staticMocks.forEach((stubs, obj) => {
+    InvalidStaticPropertyMockError.checkMockForStaticProperties(stubs);
+    Object.keys(stubs).forEach(key => {
+      const stub = stubs[key];
+      if (!testFramework.isSpy(obj[key])) {
+        testFramework.spyOn(obj, key, stub);
+      } else {
+        const spy = obj[key];
+        testFramework.resetSpy(spy);
+        testFramework.mockImplementation(spy, stub);
+      }
+    });
+  });
+};

--- a/lib/tools/ng-mock.spec.ts
+++ b/lib/tools/ng-mock.spec.ts
@@ -95,7 +95,7 @@ describe('ng-mock', () => {
       const MockedFoo = ngMock(FooComponent, testSetup);
       const foo = new MockedFoo();
 
-      expect(foo.fooOutput instanceof EventEmitter).toBe(true);
+      expect(foo.fooOutput).toBeInstanceOf(EventEmitter);
     });
 
     it('uses MockOf* in the mocked component class name', () => {

--- a/lib/tools/output-proxy.spec.ts
+++ b/lib/tools/output-proxy.spec.ts
@@ -29,7 +29,7 @@ describe('outputProxy', () => {
       String((outputs as any).notAnEventEmitter);
       fail('should have thrown an error');
     } catch (e) {
-      expect(e instanceof PropertyNotAnEventEmitterError).toBe(true);
+      expect(e).toBeInstanceOf(PropertyNotAnEventEmitterError);
     }
   });
 
@@ -38,7 +38,7 @@ describe('outputProxy', () => {
       String(outputs.notMarkedAsOutput);
       fail('should have thrown an error');
     } catch (e) {
-      expect(e instanceof PropertyNotMarkedAsOutputError).toBe(true);
+      expect(e).toBeInstanceOf(PropertyNotMarkedAsOutputError);
     }
   });
 });


### PR DESCRIPTION
Add native support for service testing: #166 

Can be used like:
```ts
beforeEach(() =>{ 
  shallow = new Shallow(MyService, MyModule);
})

it('reverses a string', () => {
  const {instance} = shallow.createService();
  expect(instance.reverse('foobar')).toBe('raboof');
});
```
