### PR TITLE
feat: Manually inject NG_VALUE_ACCESSOR instead of mocking all component providers

### DIFF
--- a/lib/shallow.ts
+++ b/lib/shallow.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { InjectionToken, PipeTransform, Provider, Type } from '@angular/core';
-import { FormsModule, ReactiveFormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule, HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
 import { RecursivePartial } from './models/recursive-partial';
 import { Renderer } from './models/renderer';
@@ -184,11 +184,4 @@ export class Shallow<TTestTarget> {
   }
 }
 
-Shallow.neverMock(
-  CommonModule,
-  BrowserModule,
-  FormsModule,
-  ReactiveFormsModule,
-  NG_VALUE_ACCESSOR,
-  HAMMER_GESTURE_CONFIG
-);
+Shallow.neverMock(CommonModule, BrowserModule, FormsModule, ReactiveFormsModule, HAMMER_GESTURE_CONFIG);

--- a/lib/tools/mock-component.spec.ts
+++ b/lib/tools/mock-component.spec.ts
@@ -60,21 +60,6 @@ describe('mockComponent', () => {
     expect(fixture.componentInstance.handleEvent).toHaveBeenCalledWith('bar');
   });
 
-  it('transforms providers', () => {
-    class FooProvider {}
-    @Component({ selector: 'my-component', providers: [FooProvider] })
-    class MyComponent {}
-
-    class BarProvider {}
-    class BazProvider {}
-    const mockedComponent = mockComponent(MyComponent, { providerTransform: () => [BarProvider, BazProvider] });
-    const mockedProviders = directiveResolver.resolve(mockedComponent).providers;
-
-    expect(mockedProviders).not.toContain(FooProvider);
-    expect(mockedProviders).toContain(BarProvider);
-    expect(mockedProviders).toContain(BazProvider);
-  });
-
   it('renders ng-content', () => {
     @Component({ selector: 'my-component' })
     class MyComponent {}

--- a/lib/tools/mock-component.ts
+++ b/lib/tools/mock-component.ts
@@ -1,21 +1,24 @@
 import { directiveResolver } from './reflect';
-import { Component, forwardRef, Type, Provider } from '@angular/core';
+import { Component, forwardRef, Type } from '@angular/core';
 import { MockOf } from './mock-of.directive';
 import { TestBed } from '@angular/core/testing';
 import { mockWithInputsOutputsAndStubs } from './mock-with-inputs-and-outputs-and-stubs';
+import { NG_VALUE_ACCESSOR, DefaultValueAccessor } from '@angular/forms';
 
 export const mockComponent = <TComponent extends Type<any>>(
   component: TComponent,
-  config?: { stubs?: object; providerTransform?: (providers: Provider[]) => Provider[] }
+  config?: { stubs?: object }
 ): TComponent => {
-  const { exportAs, selector, providers = [] } = directiveResolver.resolve(component);
-  const providerTransform = (config && config.providerTransform) || (() => []);
+  const { exportAs, selector } = directiveResolver.resolve(component);
 
   @MockOf(component)
   @Component({
     selector,
     template: '<ng-content></ng-content>',
-    providers: [{ provide: component, useExisting: forwardRef(() => Mock) }, ...providerTransform(providers)],
+    providers: [
+      { provide: component, useExisting: forwardRef(() => Mock) },
+      { provide: NG_VALUE_ACCESSOR, useClass: DefaultValueAccessor, multi: true },
+    ],
     exportAs,
   })
   class Mock extends mockWithInputsOutputsAndStubs(component, config?.stubs) {}

--- a/lib/tools/mock-directive.spec.ts
+++ b/lib/tools/mock-directive.spec.ts
@@ -60,21 +60,6 @@ describe('mockDirective', () => {
     expect(fixture.componentInstance.handleEvent).toHaveBeenCalledWith('bar');
   });
 
-  it('transforms providers', () => {
-    class FooProvider {}
-    @Directive({ selector: '[myDirective]', providers: [FooProvider] })
-    class MyDirective {}
-
-    class BarProvider {}
-    class BazProvider {}
-    const mockedDirective = mockDirective(MyDirective, { providerTransform: () => [BarProvider, BazProvider] });
-    const mockedProviders = directiveResolver.resolve(mockedDirective).providers;
-
-    expect(mockedProviders).not.toContain(FooProvider);
-    expect(mockedProviders).toContain(BarProvider);
-    expect(mockedProviders).toContain(BazProvider);
-  });
-
   it('does not render structural content by default', () => {
     @Directive({ selector: '[myDirective]' })
     class MyDirective {}

--- a/lib/tools/mock-directive.ts
+++ b/lib/tools/mock-directive.ts
@@ -1,8 +1,9 @@
-import { Directive, forwardRef, Type, Optional, ViewContainerRef, TemplateRef, OnInit, Provider } from '@angular/core';
+import { Directive, forwardRef, Type, Optional, ViewContainerRef, TemplateRef, OnInit } from '@angular/core';
 import { directiveResolver } from './reflect';
 import { MockOf } from './mock-of.directive';
 import { TestBed } from '@angular/core/testing';
 import { mockWithInputsOutputsAndStubs } from './mock-with-inputs-and-outputs-and-stubs';
+import { NG_VALUE_ACCESSOR, DefaultValueAccessor } from '@angular/forms';
 
 export type MockDirective = {
   renderContents: () => void;
@@ -11,15 +12,17 @@ export type MockDirective = {
 
 export function mockDirective<TDirective extends Type<any>>(
   directive: TDirective,
-  config?: { stubs?: object; renderContentsOnInit?: boolean; providerTransform?: (providers: Provider[]) => Provider[] }
+  config?: { stubs?: object; renderContentsOnInit?: boolean }
 ): TDirective {
-  const { selector, exportAs, providers = [] } = directiveResolver.resolve(directive);
-  const providerTransform = (config && config.providerTransform) || (() => []);
+  const { selector, exportAs } = directiveResolver.resolve(directive);
 
   @MockOf(directive)
   @Directive({
     selector: selector || `__${directive.name}-selector`,
-    providers: [{ provide: directive, useExisting: forwardRef(() => Mock) }, ...providerTransform(providers)],
+    providers: [
+      { provide: directive, useExisting: forwardRef(() => Mock) },
+      { provide: NG_VALUE_ACCESSOR, useClass: DefaultValueAccessor, multi: true },
+    ],
     exportAs,
   })
   class Mock extends mockWithInputsOutputsAndStubs(directive, config?.stubs) implements OnInit, MockDirective {

--- a/lib/tools/mock-with-inputs-and-outputs-and-stubs.ts
+++ b/lib/tools/mock-with-inputs-and-outputs-and-stubs.ts
@@ -1,22 +1,13 @@
-import { Input, Output, EventEmitter, Type, Optional } from '@angular/core';
+import { Input, Output, EventEmitter, Type } from '@angular/core';
 import { directiveResolver } from './reflect';
 import { MockWithStubs } from '../models/mock-with-stubs';
-import { NgControl } from '@angular/forms';
-import { testFramework } from '../test-frameworks/test-framework';
 
 export const mockWithInputsOutputsAndStubs = (componentOrDirective: Type<any>, stubs?: object): Type<any> => {
   const { inputs, outputs } = directiveResolver.resolve(componentOrDirective);
 
   class Mock extends MockWithStubs {
-    constructor(@Optional() ngControl: NgControl) {
+    constructor() {
       super(stubs);
-      if (ngControl && !ngControl.valueAccessor) {
-        ngControl.valueAccessor = {
-          writeValue: testFramework.createSpy(),
-          registerOnChange: testFramework.createSpy(),
-          registerOnTouched: testFramework.createSpy(),
-        };
-      }
       outputs?.map(output => output.split(': ')).forEach(([key]) => Object.assign(this, { [key]: new EventEmitter() }));
     }
   }

--- a/lib/tools/ng-mock.ts
+++ b/lib/tools/ng-mock.ts
@@ -9,8 +9,6 @@ import { mockPipe } from './mock-pipe';
 import { mockDirective } from './mock-directive';
 import { mockComponent } from './mock-component';
 import { TestBed } from '@angular/core/testing';
-import { Provider } from '@angular/compiler/src/core';
-import { mockProvider } from './mock-provider';
 
 export type NgMockable = AngularModule | Type<any> | Type<PipeTransform> | any[];
 
@@ -37,13 +35,11 @@ export function ngMock<TThing extends NgMockable | NgMockable[]>(thing: TThing, 
       mock = mockPipe(thing, setup.mockPipes.get(thing));
     } else if (isClass(thing)) {
       const stubs = setup.mocks.get(thing);
-      const providerTransform = (providers: Provider[]) => mockProvider(providers, setup);
       mock =
         declarationType(thing) === 'Component'
-          ? mockComponent(thing, { stubs, providerTransform })
+          ? mockComponent(thing, { stubs })
           : mockDirective(thing, {
               stubs,
-              providerTransform,
               renderContentsOnInit:
                 setup.withStructuralDirectives.get(thing) ||
                 (setup.alwaysRenderStructuralDirectives && setup.withStructuralDirectives.get(thing) !== false),


### PR DESCRIPTION
Taking a simpler approach to compatibility with Angular Forms components to solve for: #188 

Instead of mocking *all* component providers in hopes of successfully finding/mocking the `NG_VALUE_ACCESSOR`, we will now inject `NG_VALUE_ACCESSOR` into every mock component (whether or not it asks for it).

Pros:
* This should handle every scenario for testing mocked components that are used with `NgValue`

Cons:
* Tests for components that use mocks of components that do not actually provide `NG_VALUE_ACCESSOR` will pass when they should actually fail.