### PR TITLE
Re-add "main" in package.json to fix module resolution when importing shallow-render

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "shallow-render",
   "version": "14.1.0",
   "description": "Shallow rendering test utility for Angular",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [
     "dist",


### PR DESCRIPTION
Thanks a lot for updating shallow-render to work with Angular 14. After the update, when importing `Shallow` like this:

```
import { Shallow } from 'shallow-render';
```

I got the following error:
```
Cannot find module 'shallow-render' from [...]
```

The error occurs because in your most recent commit you changed the `"main"` entry in `package.json` to `"module"`. I was able to work around the error by importing `{ Shallow } from 'shallow-render/dist'` instead, but figured it'd make more sense to re-add the `main` entry in `package.json` again. According to the [package.json docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#main), without a `"main"` entry the import will by default look for the module in the package's root folder.