### PR TITLE
fix: Use ES2015 to avoid zonejs issues with Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "15.0.1",
   "description": "Shallow rendering test utility for Angular",
   "main": "dist/index.js",
-  "module": "dist/index.js",
   "files": [
     "dist",
     "LICENSE",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es2020"],
     "module": "commonjs",
-    "target": "es2020",
+    "target": "ES2015",
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Fixes #233 