### PR TITLE
Improve signal handling

### DIFF
--- a/lib/examples/component-with-bindings.spec.ts
+++ b/lib/examples/component-with-bindings.spec.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, input, Input, NgModule, OnChanges, Output } from '@angular/core';
+import { Component, EventEmitter, input, Input, NgModule, OnChanges, output, Output } from '@angular/core';
 import { Shallow } from '../shallow';
 
 ////// Module Setup //////
@@ -11,14 +11,14 @@ interface Person {
 @Component({
   selector: 'born-in',
   template: `
-    <label id="personLabel" (click)="selected.emit(person)">
+    <label id="personLabel" (click)="selectPerson.emit(person)">
       {{ person.firstName }} {{ person.lastName }} was born in {{ person.birthDate.getFullYear() }}
     </label>
-    <label id="partnerLabel" (click)="selected.emit(partner())">
+    <label id="partnerLabel" (click)="selectPartner.emit(partner())">
       {{ partner().firstName }} {{ partner().lastName }} was born in {{ partner().birthDate.getFullYear() }}
     </label>
     <div id="personAge">
-      {{age()}}
+      {{ age() }}
     </div>
     <label id="ngOnChangesCount">{{ ngOnChangesCount }}</label>
   `,
@@ -29,7 +29,8 @@ class BornInComponent implements OnChanges {
   age = input<string, number>("Age not provided", {
     transform: (value: number) => `${value} years old`
   });
-  @Output() selected = new EventEmitter<Person>();
+  @Output() selectPerson = new EventEmitter<Person>();
+  selectPartner = output<Person>();
 
   public ngOnChangesCount = 0;
 
@@ -75,14 +76,14 @@ describe('component with bindings', () => {
     const { find, outputs } = await shallow.render({ bind: { person, partner } });
     find('#personLabel').nativeElement.click();
 
-    expect(outputs.selected.emit).toHaveBeenCalledWith(person);
+    expect(outputs.selectPerson.emit).toHaveBeenCalledWith(person);
   });
 
   it('emits the partner when clicked', async () => {
     const { find, outputs } = await shallow.render({ bind: { person, partner } });
     find('#partnerLabel').nativeElement.click();
 
-    expect(outputs.selected.emit).toHaveBeenCalledWith(partner);
+    expect(outputs.selectPartner.emit).toHaveBeenCalledWith(partner);
   });
 
   it('updates the age considering the transform function', async () => {

--- a/lib/examples/component-with-bindings.spec.ts
+++ b/lib/examples/component-with-bindings.spec.ts
@@ -94,8 +94,8 @@ describe('component with bindings', () => {
     fixture.detectChanges();
     expect(find('#personAge').nativeElement.textContent).toContain('8 years old');
 
-    // way 2: Update using `setInput` function, similar as it's done with `ComponentRef.setInput`
-    fixture.componentInstance.setInput('age', 9);
+    // way 2: Update using `updateBinding` function, similar as it's done with `ComponentRef.updateBinding`
+    fixture.componentInstance.updateBinding('age', 9);
     fixture.detectChanges();
     expect(find('#personAge').nativeElement.textContent).toContain('9 years old');
   });

--- a/lib/examples/component-with-bindings.spec.ts
+++ b/lib/examples/component-with-bindings.spec.ts
@@ -26,8 +26,8 @@ interface Person {
 class BornInComponent implements OnChanges {
   @Input({ required: true }) person!: Person;
   partner = input.required<Person>();
-  age = input<string, number>("Age not provided", {
-    transform: (value: number) => `${value} years old`
+  age = input<string, number>('Age not provided', {
+    transform: (value: number) => `${value} years old`,
   });
   @Output() selectPerson = new EventEmitter<Person>();
   selectPartner = output<Person>();
@@ -95,7 +95,7 @@ describe('component with bindings', () => {
     expect(find('#personAge').nativeElement.textContent).toContain('8 years old');
 
     // way 2: Update using `setInput` function, similar as it's done with `ComponentRef.setInput`
-    fixture.componentInstance.setInput("age", 9);
+    fixture.componentInstance.setInput('age', 9);
     fixture.detectChanges();
     expect(find('#personAge').nativeElement.textContent).toContain('9 years old');
   });

--- a/lib/examples/component-with-bindings.spec.ts
+++ b/lib/examples/component-with-bindings.spec.ts
@@ -87,11 +87,16 @@ describe('component with bindings', () => {
 
   it('updates the age considering the transform function', async () => {
     const { find, fixture, bindings } = await shallow.render({ bind: { person: person, partner: partner, age: 7 } });
-    bindings.age = 10;
 
+    // way 1: Update using the bindings
+    bindings.age = 8;
     fixture.detectChanges();
+    expect(find('#personAge').nativeElement.textContent).toContain('8 years old');
 
-    expect(find('#personAge').nativeElement.textContent).toContain('10 years old');
+    // way 2: Update using `setInput` function, similar as it's done with `ComponentRef.setInput`
+    fixture.componentInstance.setInput("age", 9);
+    fixture.detectChanges();
+    expect(find('#personAge').nativeElement.textContent).toContain('9 years old');
   });
 
   it('displays the number of times the person was updated', async () => {

--- a/lib/examples/component-with-bindings.spec.ts
+++ b/lib/examples/component-with-bindings.spec.ts
@@ -17,12 +17,18 @@ interface Person {
     <label id="partnerLabel" (click)="selected.emit(partner())">
       {{ partner().firstName }} {{ partner().lastName }} was born in {{ partner().birthDate.getFullYear() }}
     </label>
+    <div id="personAge">
+      {{age()}}
+    </div>
     <label id="ngOnChangesCount">{{ ngOnChangesCount }}</label>
   `,
 })
 class BornInComponent implements OnChanges {
   @Input({ required: true }) person!: Person;
   partner = input.required<Person>();
+  age = input<string, number>("Age not provided", {
+    transform: (value: number) => `${value} years old`
+  });
   @Output() selected = new EventEmitter<Person>();
 
   public ngOnChangesCount = 0;
@@ -58,10 +64,11 @@ describe('component with bindings', () => {
   };
 
   it('displays the name and year the person was born', async () => {
-    const { find } = await shallow.render({ bind: { person, partner } });
+    const { find } = await shallow.render({ bind: { person, partner, age: 17 } });
 
     expect(find('#personLabel').nativeElement.textContent).toContain('Brandon Domingue was born in 1982');
     expect(find('#partnerLabel').nativeElement.textContent).toContain('John Doe was born in 1990');
+    expect(find('#personAge').nativeElement.textContent).toContain('17 years old');
   });
 
   it('emits the person when clicked', async () => {
@@ -76,6 +83,15 @@ describe('component with bindings', () => {
     find('#partnerLabel').nativeElement.click();
 
     expect(outputs.selected.emit).toHaveBeenCalledWith(partner);
+  });
+
+  it('updates the age considering the transform function', async () => {
+    const { find, fixture, bindings } = await shallow.render({ bind: { person: person, partner: partner, age: 7 } });
+    bindings.age = 10;
+
+    fixture.detectChanges();
+
+    expect(find('#personAge').nativeElement.textContent).toContain('10 years old');
   });
 
   it('displays the number of times the person was updated', async () => {

--- a/lib/models/recursive-partial.ts
+++ b/lib/models/recursive-partial.ts
@@ -2,10 +2,10 @@
  * Utility type that converts an object to recursively have optional properties.
  * This includes items an arrays and return values for functions.
  */
-import { InputSignal } from '@angular/core';
+import { InputSignal, InputSignalWithTransform } from '@angular/core';
 
 export type RecursivePartial<T> = Partial<{
-  [key in keyof T]: T[key] extends InputSignal<infer U> // Handle signals like input() and input.required()
+  [key in keyof T]: T[key] extends InputSignal<infer U> | InputSignalWithTransform<any, infer U> // Handle signals like input() and input.required()
     ? RecursivePartial<U> // Extract the type and recursively apply RecursivePartial
     : T[key] extends (...a: Array<infer U>) => any // Function-based properties (like methods or other signals)
       ? (...a: Array<U>) => RecursivePartial<ReturnType<T[key]>> | ReturnType<T[key]>

--- a/lib/models/renderer.ts
+++ b/lib/models/renderer.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Type } from '@angular/core';
+import { Directive, EventEmitter, OutputEmitterRef, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { testFramework } from '../test-frameworks/test-framework';
@@ -144,7 +144,7 @@ export class Renderer<TComponent extends object> {
     const outputs = reflect.getInputsAndOutputs(this._setup.testComponentOrService).outputs;
     outputs.forEach(({ propertyName }) => {
       const value = (instance as any)[propertyName];
-      if (value && value instanceof EventEmitter) {
+      if (value && (value instanceof EventEmitter || value instanceof OutputEmitterRef)) {
         testFramework.spyOn(value, 'emit');
       }
     });

--- a/lib/models/rendering.ts
+++ b/lib/models/rendering.ts
@@ -1,7 +1,7 @@
-import { DebugElement, EventEmitter, Type, InjectionToken, AbstractType } from '@angular/core';
+import { DebugElement, Type, InjectionToken, AbstractType } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { outputProxy, PickByType } from '../tools/output-proxy';
+import { outputProxy, OutputTypes, PickByType } from '../tools/output-proxy';
 import { createQueryMatch, QueryMatch } from './query-match';
 import { TestSetup } from './test-setup';
 import { MockDirective } from '../tools/mock-directive';
@@ -44,7 +44,7 @@ export class Rendering<TComponent extends object, TBindings> {
     private readonly _setup: TestSetup<TComponent>,
   ) {}
 
-  readonly outputs: PickByType<TComponent, EventEmitter<any>> = outputProxy(this.instance);
+  readonly outputs: PickByType<TComponent, OutputTypes> = outputProxy(this.instance);
 
   /////////////////////////////////////////////////////////////////////////////
   // The following methods MUST be arrow functions so they can be deconstructured

--- a/lib/tools/create-container.spec.ts
+++ b/lib/tools/create-container.spec.ts
@@ -31,7 +31,7 @@ describe('createContainerComponent', () => {
     const container: any = new Container();
 
     container.setInput('foo', 'fooo');
-    
+
     expect(container.foo).toBe('fooo');
   });
 });

--- a/lib/tools/create-container.spec.ts
+++ b/lib/tools/create-container.spec.ts
@@ -24,4 +24,14 @@ describe('createContainerComponent', () => {
     container.foo();
     expect(container.foo).toHaveBeenCalled();
   });
+
+  it('provides method to set the input', () => {
+    const bindings: any = { foo: 'foo', bar: 'bar' };
+    const Container = createContainer('', bindings);
+    const container: any = new Container();
+
+    container.setInput('foo', 'fooo');
+    
+    expect(container.foo).toBe('fooo');
+  });
 });

--- a/lib/tools/create-container.spec.ts
+++ b/lib/tools/create-container.spec.ts
@@ -30,7 +30,7 @@ describe('createContainerComponent', () => {
     const Container = createContainer('', bindings);
     const container: any = new Container();
 
-    container.setInput('foo', 'fooo');
+    container.updateBinding('foo', 'fooo');
 
     expect(container.foo).toBe('fooo');
   });

--- a/lib/tools/create-container.ts
+++ b/lib/tools/create-container.ts
@@ -6,15 +6,21 @@ export class ShallowRenderContainer {}
 export function createContainer(template: string, bindings: any): Type<ShallowRenderContainer> {
   @Component({ template })
   class ProxyShallowContainerComponent extends ShallowRenderContainer {
+    bindings: any;
     constructor() {
       super();
       const spies = spyOnBindings(bindings);
+      this.bindings = spies;
       Object.defineProperties(
         ProxyShallowContainerComponent.prototype,
         Object.keys(spies).reduce((acc, key) => {
-          return { ...acc, [key]: { get: () => spies[key] } };
+          return { ...acc, [key]: { get: () => this.bindings[key] } };
         }, {}),
       );
+    }
+
+    setInput(name: string, value: any): void {
+      this.bindings[name] = value;
     }
   }
 

--- a/lib/tools/create-container.ts
+++ b/lib/tools/create-container.ts
@@ -6,20 +6,19 @@ export class ShallowRenderContainer {}
 export function createContainer(template: string, bindings: any): Type<ShallowRenderContainer> {
   @Component({ template })
   class ProxyShallowContainerComponent extends ShallowRenderContainer {
-    bindings: any;
+    private bindings: any;
     constructor() {
       super();
-      const spies = spyOnBindings(bindings);
-      this.bindings = spies;
+      this.bindings = spyOnBindings(bindings);
       Object.defineProperties(
         ProxyShallowContainerComponent.prototype,
-        Object.keys(spies).reduce((acc, key) => {
+        Object.keys(this.bindings).reduce((acc, key) => {
           return { ...acc, [key]: { get: () => this.bindings[key] } };
         }, {}),
       );
     }
 
-    setInput(name: string, value: any): void {
+    updateBinding(name: string, value: any): void {
       this.bindings[name] = value;
     }
   }

--- a/lib/tools/output-proxy.spec.ts
+++ b/lib/tools/output-proxy.spec.ts
@@ -1,9 +1,10 @@
 import { Component, EventEmitter, output, Output } from '@angular/core';
 import {
-  outputProxy, OutputTypes,
+  outputProxy,
+  OutputTypes,
   PickByType,
   PropertyNotAnEventEmitterOrSignalOutputError,
-  PropertyNotMarkedAsOutputError
+  PropertyNotMarkedAsOutputError,
 } from './output-proxy';
 import { TestBed } from '@angular/core/testing';
 
@@ -23,10 +24,9 @@ describe('outputProxy', () => {
   let outputs: PickByType<FooComponent, OutputTypes>;
 
   beforeEach(async () => {
+    await TestBed.configureTestingModule({}).compileComponents();
 
-    await TestBed.configureTestingModule({}).compileComponents()
-
-    const fixture = TestBed.createComponent(FooComponent)
+    const fixture = TestBed.createComponent(FooComponent);
     component = fixture.componentInstance;
     outputs = outputProxy(component);
   });

--- a/lib/tools/output-proxy.spec.ts
+++ b/lib/tools/output-proxy.spec.ts
@@ -1,27 +1,33 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, output, Output } from '@angular/core';
 import {
-  outputProxy,
+  outputProxy, OutputTypes,
   PickByType,
-  PropertyNotAnEventEmitterError,
-  PropertyNotMarkedAsOutputError,
+  PropertyNotAnEventEmitterOrSignalOutputError,
+  PropertyNotMarkedAsOutputError
 } from './output-proxy';
+import { TestBed } from '@angular/core/testing';
 
 describe('outputProxy', () => {
   @Component({
     selector: 'Foo',
-    template: '<h1/>',
+    template: '<h1>Foo</h1>',
   })
   class FooComponent {
     @Output() normalOutput = new EventEmitter<string>();
     @Output() notAnEventEmitter = 'foo';
     @Output('renamed') renamedOutput = new EventEmitter<string>();
+    signalOutput = output<string>();
     notMarkedAsOutput = new EventEmitter<string>();
   }
   let component: FooComponent;
-  let outputs: PickByType<FooComponent, EventEmitter<any>>;
+  let outputs: PickByType<FooComponent, OutputTypes>;
 
-  beforeEach(() => {
-    component = new FooComponent();
+  beforeEach(async () => {
+
+    await TestBed.configureTestingModule({}).compileComponents()
+
+    const fixture = TestBed.createComponent(FooComponent)
+    component = fixture.componentInstance;
     outputs = outputProxy(component);
   });
 
@@ -33,12 +39,16 @@ describe('outputProxy', () => {
     expect(outputs.renamedOutput).toBe(component.renamedOutput);
   });
 
+  it('works with signal outputs', () => {
+    expect(outputs.signalOutput).toBe(component.signalOutput);
+  });
+
   it('throws an error if the property is not an EventEmitter', () => {
     try {
       String((outputs as any).notAnEventEmitter);
       fail('should have thrown an error');
     } catch (e) {
-      expect(e).toBeInstanceOf(PropertyNotAnEventEmitterError);
+      expect(e).toBeInstanceOf(PropertyNotAnEventEmitterOrSignalOutputError);
     }
   });
 

--- a/lib/tools/output-proxy.ts
+++ b/lib/tools/output-proxy.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@angular/core';
+import { EventEmitter, OutputEmitterRef } from '@angular/core';
 import { CustomError } from '../models/custom-error';
 import { reflect } from './reflect';
 
@@ -10,6 +10,8 @@ export type KeysOfType<TObject, TPropertyType> = {
 
 export type PickByType<TObject, TPropertyType> = Pick<TObject, KeysOfType<TObject, TPropertyType>>;
 
+export type OutputTypes = EventEmitter<any> | OutputEmitterRef<any>;
+
 export class PropertyNotMarkedAsOutputError extends CustomError {
   constructor(key: string | symbol | number, component: any) {
     super(
@@ -19,10 +21,10 @@ export class PropertyNotMarkedAsOutputError extends CustomError {
   }
 }
 
-export class PropertyNotAnEventEmitterError extends CustomError {
+export class PropertyNotAnEventEmitterOrSignalOutputError extends CustomError {
   constructor(key: string | symbol | number, component: any) {
     super(
-      `${String(key)} is not an instance of an EventEmitter. ` +
+      `${String(key)} is not an instance of an EventEmitter or a Signal Output. ` +
         `Check that it is properly defined and set on the ${className(component)} class`,
     );
   }
@@ -31,7 +33,7 @@ export class PropertyNotAnEventEmitterError extends CustomError {
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const outputProxy = <TComponent extends Object>(
   component: TComponent,
-): PickByType<TComponent, EventEmitter<any>> => {
+): PickByType<TComponent, OutputTypes> => {
   const outputs = reflect.getInputsAndOutputs(component.constructor).outputs.map(o => o.propertyName);
 
   return new Proxy(
@@ -42,8 +44,8 @@ export const outputProxy = <TComponent extends Object>(
           throw new PropertyNotMarkedAsOutputError(key, component);
         }
         const maybeOutput = (component as any)[key];
-        if (!(maybeOutput instanceof EventEmitter)) {
-          throw new PropertyNotAnEventEmitterError(key, component);
+        if (!(maybeOutput instanceof EventEmitter) && !(maybeOutput instanceof OutputEmitterRef)) {
+          throw new PropertyNotAnEventEmitterOrSignalOutputError(key, component);
         }
 
         return maybeOutput;

--- a/lib/tools/output-proxy.ts
+++ b/lib/tools/output-proxy.ts
@@ -31,9 +31,7 @@ export class PropertyNotAnEventEmitterOrSignalOutputError extends CustomError {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export const outputProxy = <TComponent extends Object>(
-  component: TComponent,
-): PickByType<TComponent, OutputTypes> => {
+export const outputProxy = <TComponent extends Object>(component: TComponent): PickByType<TComponent, OutputTypes> => {
   const outputs = reflect.getInputsAndOutputs(component.constructor).outputs.map(o => o.propertyName);
 
   return new Proxy(


### PR DESCRIPTION
This PR addresses multiple issues when working with signal inputs and outputs:

- Provides support for [input signals with transform](https://angular.dev/api/core/InputSignalWithTransform)
- Provides support for [output signals](https://angular.dev/api/core/output)
- Provides helper method to overwrite a single input in a test by adding `updateBinding` on `ProxyShallowContainerComponent `

Please also backport this change to angular 18 .
